### PR TITLE
Add azure-storage-blob to qio quickstart

### DIFF
--- a/articles/quickstart-microsoft-qio.md
+++ b/articles/quickstart-microsoft-qio.md
@@ -91,6 +91,7 @@ installed the Python SDK for optimization already, follow these steps:
 
    ```bash
    pip install --upgrade azure-quantum --pre
+   pip install azure-storage-blob --upgrade
    ```
 
 ## Create a `Workspace` object in your Python code and log in


### PR DESCRIPTION
Because the azure meta package is deprecated, specific installation of
certain packages is necessary. That list includes azure-storage-blob,
which is necessary to import Workspace from azure.quantum.