### PR TITLE
Fix LaTeX in multiple qubits

### DIFF
--- a/articles/concepts-multiple-qubits.md
+++ b/articles/concepts-multiple-qubits.md
@@ -31,7 +31,7 @@ $$
 = \begin{bmatrix} \alpha\gamma \\\\  \alpha\delta \\\\  \beta\gamma \\\\  \beta\delta \end{bmatrix}.
 $$
 
-Therefore, given two single-qubit states $\psi and \phi$, each of dimension 2, the corresponding two-qubit state $\psi \otimes \phi$ is 4-dimensional. The vector
+Therefore, given two single-qubit states $\psi$ and $\phi$, each of dimension 2, the corresponding two-qubit state $\psi \otimes \phi$ is 4-dimensional. The vector
 
 $$
 \begin{bmatrix} \alpha_{00} \\\\  \alpha_{01} \\\\  \alpha_{10} \\\\  \alpha_{11} \end{bmatrix}


### PR DESCRIPTION
Add missing `$`s around `\phi` and `\psi` ‘Representing two qubits’ section.