### PR TITLE
Remove mentions of Codespaces from install guides

### DIFF
--- a/articles/install-command-line-qdk.md
+++ b/articles/install-command-line-qdk.md
@@ -13,7 +13,7 @@ uid: microsoft.quantum.install-qdk.overview.standalone
 
 # Develop with Q# applications in an IDE
 
-Learn how to develop Q# applications in Visual Studio Code (VS Code), Visual Studio, Visual Studio Codespaces, or with any editor/IDE and run applications from the .NET console. Q# programs can run on their own, without a driver in a host language like C#, F#, or Python.
+Learn how to develop Q# applications in Visual Studio Code (VS Code), Visual Studio, or with any editor/IDE and run applications from the .NET console. Q# programs can run on their own, without a driver in a host language like C#, F#, or Python.
 
 ## Prerequisites for all environments
 
@@ -21,7 +21,7 @@ Learn how to develop Q# applications in Visual Studio Code (VS Code), Visual Stu
 
 ## Installation
 
-While you can build Q# applications in any IDE, we recommend using Visual Studio Code (VS Code) or Visual Studio IDE for developing your Q# applications locally. For developing in the Cloud via the web browser, we recommend Visual Studio Codespaces. Developing in these environments leverages the rich functionality of the Quantum Development Kit (QDK) extension, which includes warnings, syntax highlighting, project templates, and more.
+While you can build Q# applications in any IDE, we recommend using Visual Studio Code (VS Code) or Visual Studio IDE for developing your Q# applications locally. Developing in these environments leverages the rich functionality of the Quantum Development Kit (QDK) extension, which includes warnings, syntax highlighting, project templates, and more.
 
 > [!IMPORTANT]
 > If you are working on Linux, you may encounter a missing dependency depending on your particular distribution and installation method (e.g. certain Docker images). Please make sure that the `libgomp` library is installed on your system, as the GNU OpenMP support library is required by the quantum simulator of the QDK. On Ubuntu, you can do so by running `sudo apt install libgomp1`, or `yum install libgomp` on CentOS. For other distributions, please refer to your particular package manager.

--- a/articles/install-overview-qdk.md
+++ b/articles/install-overview-qdk.md
@@ -25,7 +25,7 @@ The QDK consists of:
 
 ## Set up the Quantum Development Kit to develop quantum computing applications in Q#
 
-Q# programs can run as standalone applications using Visual Studio Code or Visual Studio, through Jupyter Notebooks with the IQ# Jupyter kernel, or paired with a host program written in Python or a .NET language (C#, F#). You can also run Q# programs online using [Codespaces](https://online.visualstudio.com/), [MyBinder.org](https://mybinder.org/), or [Docker](#use-the-qdk-for-quantum-computing-with-docker).
+Q# programs can run as standalone applications using Visual Studio Code or Visual Studio, through Jupyter Notebooks with the IQ# Jupyter kernel, or paired with a host program written in Python or a .NET language (C#, F#). You can also run Q# programs online using [MyBinder.org](https://mybinder.org/), or [Docker](#use-the-qdk-for-quantum-computing-with-docker).
 
 ### Options for setting up the QDK for quantum computing
 
@@ -88,7 +88,6 @@ You can also develop Q# code without installing anything locally with these opti
 
 |Resource|Advantages|Limitations|
 |---|---|---|
-|[**Visual Studio Codespaces**](xref:microsoft.quantum.install-qdk.overview.standalone)|A rich online development environment  |Requires an Azure subscription and plan |
 |[**Binder**](xref:microsoft.quantum.install-qdk.overview.binder) | Free online notebook experience |No persistence |
 
 ### Use the QDK for quantum computing with Docker


### PR DESCRIPTION
We removed Codespaces from the documentation because it's in private preview. This PR cleans up leftover mentions