### PR TITLE
Replace wrong code samples links

### DIFF
--- a/articles/how-to-create-applications-for-azure-quantum.md
+++ b/articles/how-to-create-applications-for-azure-quantum.md
@@ -66,7 +66,7 @@ Follow these steps in this section to create an application to run in IonQ targe
 - Install the [QDK](xref:microsoft.quantum.install-qdk.overview.standalone).
 - A Quantum Workspace with IonQ listed as a provider. To create a Workspace, see [Create an Azure Quantum workspace](xref:microsoft.quantum.workspaces-portal).
 
-#### Steps 
+#### Steps
 
 1. [Create a Q# application using the Q# project template.](xref:microsoft.quantum.install-qdk.overview.standalone)
 1. Open the `*.csproj` file in a text editor (for example, VS Code) and edit the file to:
@@ -122,5 +122,5 @@ however, we are planning to make some available during the Limited Review.
 
 ## Next steps
 
-- Now that you know how to create Q# applications, you can learn more details about [how to submit jobs to Azure Quantum](xref:microsoft.quantum.submit-jobs.azcli). 
-- You can also  try the different [samples](https://github.com/microsoft/qio-samples) we have available or try to submit your own projects.
+- Now that you know how to create Q# applications, you can learn more details about [how to submit jobs to Azure Quantum](xref:microsoft.quantum.submit-jobs.azcli).
+- You can also  try the different [samples](https://github.com/microsoft/Quantum/tree/main/samples/azure-quantum) we have available or try to submit your own projects.

--- a/articles/how-to-submit-jobs-with-azure-cli.md
+++ b/articles/how-to-submit-jobs-with-azure-cli.md
@@ -218,5 +218,5 @@ Note that the IonQ simulator gives the probabilities of obtaining each output if
 ## Next steps
 
 Now that you know how to submit jobs to Azure quantum, you can try to run the
-different [samples](https://github.com/microsoft/qio-samples) we have
+different [samples](https://github.com/microsoft/Quantum/tree/main/samples/azure-quantum) we have
 available or try to submit your own projects.

--- a/articles/how-to-submit-jobs-with-jupyter-notebooks.md
+++ b/articles/how-to-submit-jobs-with-jupyter-notebooks.md
@@ -15,7 +15,7 @@ uid: microsoft.quantum.submit-jobs.jupyter
 This document provides a basic guide to submit and run Q# applications in Azure
 Quantum using Q# Jupyter Notebooks.
 
-## Prerequisites 
+## Prerequisites
 
 - An Azure Quantum workspace in your Azure subscription. To create
   a workspace, see [Create an Azure Quantum
@@ -113,5 +113,5 @@ Some helpful tips while using Q# Jupyter Notebooks:
 ## Next steps
 
 Now that you know how to submit jobs to Azure Quantum, you can try to run the
-different [samples](https://github.com/microsoft/qio-samples) we have
+different [samples](https://github.com/microsoft/Quantum/tree/main/samples/azure-quantum) we have
 available or try to submit your own projects. In particular, you can view a sample written entirely in a Q# Jupyter notebook.

--- a/articles/how-to-submit-jobs-with-python.md
+++ b/articles/how-to-submit-jobs-with-python.md
@@ -138,5 +138,5 @@ quantum programs on Azure Quantum.
 
 ## Next steps
 
-Now that you know how to submit jobs to Azure Quantum, you can try to run the different [samples](https://github.com/microsoft/qio-samples) we have
+Now that you know how to submit jobs to Azure Quantum, you can try to run the different [samples](https://github.com/microsoft/Quantum/tree/main/samples/azure-quantum) we have
 available or try to submit your own projects.

--- a/articles/quickstart-honeywell.md
+++ b/articles/quickstart-honeywell.md
@@ -224,6 +224,6 @@ This quickstart guide demonstrated how to get started running Q# programs agains
 
 We recommend you continue your journey by learning more about the [different types of targets in Azure Quantum](xref:microsoft.quantum.concepts.targets), which will dictate which Q# programs you may run against a given provider. You might also be interested in learning how to submit Q# jobs with [Jupyter Notebooks](xref:microsoft.quantum.submit-jobs.jupyter) or with [Python](xref:microsoft.quantum.submit-jobs.python).
 
-Looking for more samples to run? Check out the [samples directory](https://github.com/microsoft/qio-samples).
+Looking for more samples to run? Check out the [samples directory](https://github.com/microsoft/Quantum/tree/main/samples/azure-quantum) for Azure Quantum.
 
 Lastly, if you would like to learn more about writing Q# programs please see the [Microsoft Quantum Documentation](xref:microsoft.quantum.overview.qdk-overview).

--- a/articles/quickstart-ionq.md
+++ b/articles/quickstart-ionq.md
@@ -261,6 +261,6 @@ This quickstart guide demonstrated how to get started running Q# programs agains
 
 We recommend you continue your journey by learning more about the [different types of targets in Azure Quantum](xref:microsoft.quantum.concepts.targets), which will dictate which Q# programs you may run against a given provider. You might also be interested in learning how to submit Q# jobs with [Jupyter Notebooks](xref:microsoft.quantum.submit-jobs.jupyter) or with [Python](xref:microsoft.quantum.submit-jobs.python).
 
-Looking for more samples to run? Check out the [samples directory](https://github.com/microsoft/qio-samples).
+Looking for more samples to run? Check out the [samples directory](https://github.com/microsoft/Quantum/tree/main/samples/azure-quantum) for Azure Quantum.
 
 Lastly, if you would like to learn more about writing Q# programs please see the [Microsoft Quantum Documentation](xref:microsoft.quantum.overview.qdk-overview).


### PR DESCRIPTION
Links in the QC Azure Quantum documentation which mistakenly point the user to the QIO samples repo have been replaced with links to the Azure Quantum samples inside the QDK samples repo.

Closes #107 