### PR TITLE
Update naming and instructions for the Python SDK for Azure Quantum

### DIFF
--- a/articles/TOC.yml
+++ b/articles/TOC.yml
@@ -62,7 +62,7 @@
         href: quickstart-1qbit.md 
     - name: How-to guides
       items:
-      - name: Install and use the Python SDK for optimization
+      - name: Install and use the Python SDK for Azure Quantum
         href: optimization-install-sdk.md
       - name: Troubleshoot optimization solvers
         href: optimization-troubleshooting.md

--- a/articles/TOC.yml
+++ b/articles/TOC.yml
@@ -56,8 +56,6 @@
     items:
     - name: Quickstarts
       items:
-      - name: Install and use the Python SDK for optimization
-        href: optimization-install-sdk.md
       - name: Microsoft QIO quickstart
         href: quickstart-microsoft-qio.md
       - name: 1QBit quickstart

--- a/articles/index.yml
+++ b/articles/index.yml
@@ -72,7 +72,7 @@ landingContent:
           url: optimization-what-is-quantum-optimization.md
       - linkListType: how-to-guide 
         links:
-          - text: Install the Python SDK for optimization
+          - text: Install the Python SDK for Azure Quantum
             url: optimization-install-sdk.md
       - linkListType: learn
         links:

--- a/articles/install-overview-qdk.md
+++ b/articles/install-overview-qdk.md
@@ -20,7 +20,7 @@ The QDK consists of:
 - The Q# programming language
 - A set of libraries that abstract complex functionality in Q#
 - APIs for Python and .NET languages (C#, F#, and VB.NET) for running quantum programs written in Q#
-- A Python SDK to handle use optimization solvers on Azure Quantum
+- A Python SDK to use optimization solvers on Azure Quantum
 - Tools to facilitate your development
 
 ## Set up the Quantum Development Kit to develop quantum computing applications in Q#
@@ -104,4 +104,4 @@ The workflows for each of these setups are described and compared in [Ways to ru
 
 You can use the Python SDK of the Quantum Development Kit to solve optimization problems using Azure Quantum solvers. 
 
-To set up the Python SDK, follow the steps in [Install and use the Python SDK for optimization](xref:microsoft.quantum.optimization.install-sdk).
+To set up the Python SDK, follow the steps in [Install and use the Python SDK for Azure Quantum](xref:microsoft.quantum.optimization.install-sdk).

--- a/articles/optimization-install-sdk.md
+++ b/articles/optimization-install-sdk.md
@@ -1,45 +1,44 @@
 ---
 author: anraman
-description: This document provides a basic installation and usage overview of the Python SDK for optimization.
+description: This document provides a basic installation and usage overview of the Python SDK for Azure Quantum.
 ms.author: anraman
 ms.date: 02/01/2021
 ms.service: azure-quantum
 ms.subservice: optimization
 ms.topic: conceptual
-title: Install and use the Python SDK for optimization
+title: Install and use the Python SDK for Azure Quantum
 uid: microsoft.quantum.optimization.install-sdk
 ---
 
-# Install and use the Python SDK for optimization
+# Install and use the Python Python SDK for Azure Quantum
 
-This guide provides a basic overview of how to install and use the Python SDK for optimization.
+This guide provides a basic overview of how to install and use the Python SDK for Azure Quantum.
 
 ## Prerequisites
 
 - An Azure Quantum workspace created in your Azure subscription. To create a workspace, see [Create an Azure Quantum workspace](xref:microsoft.quantum.workspaces-portal).
 
-## Python SDK for optimization installation
+## Python SDK for Azure Quantum installation
 
-The Python SDK is distributed as the `azure-quantum` [PyPI](https://pypi.org)
-package. To install the package you will need to follow the steps below:
+The Python SDK is distributed as the `azure-quantum` [PyPI](https://pypi.org/project/azure-quantum/) package. To install the package you will need to follow the steps below:
 
 1. Install [Python](https://www.python.org/downloads/) 3.6 or later.
-2. Install [PIP](https://pip.pypa.io/en/stable/), the Python Package Installer, and ensure you have **version 19.2 or higher**
-3. Install the `azure-quantum` Python package:
+2. Install [PIP](https://pip.pypa.io/en/stable/), the Python Package Installer, and ensure you have **version 19.2 or higher**.
+3. Install the latest `azure-quantum` Python package:
 
-   ```bash
-   pip install azure-quantum
+   ```Shell
+   pip install --upgrade azure-quantum
    ```
 
 ## Jupyter Notebooks installation
 
 You can also choose to interact with Azure Quantum optimization using Jupyter Notebooks. In order to do this, you will need to:
 
-1. Install the Python SDK for optimization (as described in the previous section)
+1. Install the Python SDK for Azure Quantum (as described in the previous section)
 2. [Install Jupyter Notebooks](https://jupyter.org/install)
 3. In your terminal of choice, use the following command to launch a new Jupyter Notebook:
 
-    ```bash
+    ```Shell
     jupyter notebook
     ```
 

--- a/articles/optimization-overview-key-concepts.md
+++ b/articles/optimization-overview-key-concepts.md
@@ -182,7 +182,7 @@ $$
 (w_{0} + w_{1})x_{0}x_{1}
 $$
 
-Expressed in terms of code (using the [QIO Python SDK](https://docs.microsoft.com/azure/quantum/optimization-express-optimization-problem)):
+Expressed in terms of code (using the [Python SDK](https://docs.microsoft.com/azure/quantum/optimization-express-optimization-problem)):
 ```
 term1 = Term(c=2, indices=[0,1])
 term2 = Term(c=3, indices=[1,0])

--- a/articles/overview-azure-quantum.md
+++ b/articles/overview-azure-quantum.md
@@ -63,7 +63,7 @@ Once you create a job, various metadata is available about its state and run his
 
 ## Job lifecycle
 
-You typically create jobs using one of the quantum SDKs (for example, the [Python SDK](xref:microsoft.quantum.optimization.install-sdk) or the [Quantum Development Kit (QDK)](xref:microsoft.quantum.overview.q-sharp)). Once you've written
+You typically create jobs using one of the quantum SDKs (for example, the [Python SDK for Azure Quantum](xref:microsoft.quantum.optimization.install-sdk) or the [Quantum Development Kit (QDK)](xref:microsoft.quantum.overview.q-sharp)). Once you've written
 your quantum program or expressed your QIO problem, you can select a target and
 submit your job.
 

--- a/articles/quickstart-1qbit.md
+++ b/articles/quickstart-1qbit.md
@@ -84,16 +84,15 @@ The goal is to find the configuration that yields the lowest possible value of $
 > [!NOTE]
 > For a detailed walkthrough of the problem scenario and how the cost function is constructed, please refer to the [sample](https://github.com/microsoft/qio-samples) and/or the associated [Microsoft Learn module](https://docs.microsoft.com/learn/modules/solve-quantum-inspired-optimization-problems/).
 
-## Install the Python SDK for optimization
+## Install the Python SDK for Azure Quantum
 
-To implement a solution, first ensure that you have the Optimization Python SDK installed on your machine. If you haven't
-installed the Optimization Python SDK already, follow these steps:
+To implement a solution, first ensure that you have the Python SDK for Azure Quantum installed on your machine. If you don't have it installed yet, follow these steps:
 
 1. Install [Python](https://www.python.org/downloads/) 3.6 or later in case you haven't already.
 1. Install [PIP](https://pip.pypa.io/en/stable/) and ensure you have **version 19.2 or higher**.
 1. Install the `azure-quantum` python package.
 
-   ```bash
+   ```Shell
    pip install --upgrade azure-quantum
    ```
 

--- a/articles/quickstart-microsoft-qio.md
+++ b/articles/quickstart-microsoft-qio.md
@@ -79,18 +79,16 @@ The goal is to find the configuration that yields the lowest possible value of $
 > [!NOTE]
 > For a detailed walkthrough of the problem scenario and how the cost function is constructed, please refer to the [sample](https://github.com/microsoft/qio-samples/tree/main/samples/ship-loading/) and/or the associated [Microsoft Learn module](https://docs.microsoft.com/learn/modules/solve-quantum-inspired-optimization-problems/).
 
-## Install the Python SDK for optimization
+## Install the Python SDK for Azure Quantum
 
-To implement a solution, first ensure that you have the Python SDK for optimization installed on your machine. If you haven't
-installed the Python SDK for optimization already, follow these steps:
+To implement a solution, first ensure that you have the Python SDK for Azure Quantum installed on your machine. If you don't have it installed yet, follow these steps:
 
 1. Install [Python](https://www.python.org/downloads/) 3.6 or later in case you haven't already.
 1. Install [PIP](https://pip.pypa.io/en/stable/) and ensure you have **version 19.2 or higher**.
 1. Install the `azure-quantum` python package.
 
-   ```bash
-   pip install --upgrade azure-quantum --pre
-   pip install azure-storage-blob --upgrade
+   ```Shell
+   pip install --upgrade azure-quantum
    ```
 
 ## Create a `Workspace` object in your Python code and log in


### PR DESCRIPTION
Use same installation commands across articles, replacing e.g. the private preview commands. Now:
```pip install --upgrade azure-quantum```

Use official [package name](https://pypi.org/project/azure-quantum/).