### PR TITLE
Fix misspelled cross-reference to reusing problem definitions

### DIFF
--- a/articles/optimization-install-sdk.md
+++ b/articles/optimization-install-sdk.md
@@ -120,6 +120,7 @@ This method will submit the problem to Azure Quantum for optimization and synchr
 ```output
 {'configuration': {'0': 1, '1': 1, '2': -1, '3': 1}, 'cost': -32.0}
 ```
+
 > [!NOTE]
 > If you run into an error while working with Azure Quantum, you can check our [list of common issues](xref:microsoft.quantum.azure.common-issues). Also if your are using an optimization solver and you get an error in the form <AZQxxx>, you can check our [list of common user errors in optimization solvers](xref:azure.quantum.optimization.troubleshooting).
 

--- a/articles/optimization-problem.md
+++ b/articles/optimization-problem.md
@@ -107,7 +107,7 @@ problem.evaluate({0:1, 1:0})
 
 ### Problem.set_fixed_variables
 
-During experimentation, the user may want to set a variable (or a group of variables) to a particular value. Calling set_fixed_variables will return a new Problem object representing the modified problem after such variables have been fixed. 
+During experimentation, the user may want to set a variable (or a group of variables) to a particular value. Calling set_fixed_variables will return a new Problem object representing the modified problem after such variables have been fixed.
 
 ```py
 fixed_var = {'1': 1, '2': 1}
@@ -140,7 +140,7 @@ terms
 
 ## StreamingProblem
 
-StreamingProblem class can handle large problems that exceeds local memory limits. Unlike with the Problem class, terms in the StreamingProblem are uploaded directly to blob and are not kept in memory.  
+StreamingProblem class can handle large problems that exceeds local memory limits. Unlike with the Problem class, terms in the StreamingProblem are uploaded directly to blob and are not kept in memory.
 
 The StreamingProblem class uses the same interface as the Problem class.
 
@@ -152,5 +152,4 @@ There are some features not supported yet on the StreamingProblem class due to i
 ## OnlineProblem
 
 OnlineProblem class creates a problem from the url of the blob storage where an optimization problem has been uploaded. It is essentially used to reusing already submitted problems.
-It does not support client side analysis eg: evaluate and set_fixed_variables. It allows you to download the problem from the blob storage as an instance of the Problem class to do any of the client side operations.
-For an example of how to use the OnlineProblem class see [here](xref:microsoft.quantum.optimization.reuse-problem-definition))
+It does not support client side analysis eg: evaluate and set_fixed_variables. It allows you to download the problem from the blob storage as an instance of the Problem class to do any of the client side operations. For an example of how to use the OnlineProblem class, have a look at [reusing problem definitions](xref:microsoft.quantum.optimization.reuse-problem-definitions).

--- a/articles/optimization-reuse-problem-definitions.md
+++ b/articles/optimization-reuse-problem-definitions.md
@@ -12,18 +12,19 @@ uid: microsoft.quantum.optimization.reuse-problem-definitions
 
 # Reusing problem definitions
 
-Sometimes it is more efficient to upload a problem definition once and find its solution using different algorithms (solvers) or with different parameters. You can upload a problem definition using the `upload` method, which returns a URL, then provide this URL to a solver's `submit` or optimize` methods:
+Sometimes it is more efficient to upload a problem definition once and find its solution using different algorithms (solvers) or with different parameters. You can upload a problem definition using the `upload` method, which returns a URL, and then provide this URL to a solver's `submit` or `optimize` methods:
 
 ```py
 url = problem.upload(workspace)
 job = solver.submit(url)
 print(job.id)
+```
 
+```output
 > 9228ea88-6832-11ea-8271-c49dede60d7c
 ```
 
-You can also create an online problem from  the submitted url and assign it a name. This OnlineProblem object also allows you to download the problem and get the terms of the problem to perform any client side analysis (set_fixed_variables, 
-evaluate the cost function for a configuration or get specific terms from variable ids)
+You can also create an online problem from the submitted url and assign it a name. This OnlineProblem object also allows you to download the problem and get the terms of the problem to perform any client side analysis (set_fixed_variables, evaluate the cost function for a configuration or get specific terms from variable ids):
 
 ```py
 online_problem = OnlineProblem(name = "o_prob", blob_uri = url)


### PR DESCRIPTION
`microsoft.quantum.optimization.reuse-problem-definition` -> `microsoft.quantum.optimization.reuse-problem-definitions`

Also contains other smaller typo and formatting fixes

Closes #192 