### PR TITLE
Various Docs improvements for QDK, AQ, and Python articles

### DIFF
--- a/articles/how-to-submit-jobs-with-jupyter-notebooks.md
+++ b/articles/how-to-submit-jobs-with-jupyter-notebooks.md
@@ -17,36 +17,13 @@ Quantum using Q# Jupyter Notebooks.
 
 ## Prerequisites
 
-- An Azure Quantum workspace in your Azure subscription. To create
-  a workspace, see [Create an Azure Quantum
-  workspace](xref:microsoft.quantum.workspaces-portal).
+- An Azure Quantum workspace in your Azure subscription. To create a workspace,
+  see [Create an Azure Quantum workspace](xref:microsoft.quantum.workspaces-portal).
+- The latest version of the [Quantum Development Kit for Jupyter Notebooks](xref:microsoft.quantum.install-qdk.overview.jupyter#install-the-iq-jupyter-kernel).
 
-## Installation
-
-Follow these steps to install Jupyter Notebook and the current version of the
-IQ# kernel, which powers the Q# Jupyter Notebook and Python experiences.
-
-1. Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or
-   [Anaconda](https://www.anaconda.com/products/individual#Downloads).
-1. Open an Anaconda Prompt.
-   - Or, if you prefer to use PowerShell or pwsh: open a shell, run `conda init
-     powershell`, then close and re-open the shell.
-1. Create and activate a new conda environment named `qsharp-env` with the
-   required packages (including Jupyter Notebook and IQ#) by running the
-   following commands:
-
-    ```bash
-    conda create -n qsharp-env -c quantum-engineering qsharp notebook
-
-    conda activate qsharp-env
-    ```
-
-1. Run `python -c "import qsharp"` from the same terminal to verify your
-   installation and populate your local package cache with all of the required QDK
-   components.
-
-You are now set up to use Q# Jupyter Notebooks and Q# integration to run
-quantum programs on Azure Quantum.
+Follow the installation steps in the provided link to install Jupyter Notebook and
+the current version of the IQ# kernel, which powers the Q# Jupyter Notebook and
+Python experiences.
 
 ## Quantum computing with Q# Jupyter Notebooks
 

--- a/articles/how-to-submit-jobs-with-python.md
+++ b/articles/how-to-submit-jobs-with-python.md
@@ -17,35 +17,13 @@ Quantum using Python.
 
 ## Prerequisites
 
-- An Azure Quantum workspace in your Azure subscription. To create
-  a workspace, see [Create an Azure Quantum workspace](xref:microsoft.quantum.workspaces-portal).
+- An Azure Quantum workspace in your Azure subscription. To create a workspace,
+  see [Create an Azure Quantum workspace](xref:microsoft.quantum.workspaces-portal).
+- The latest version of the [Quantum Development Kit for Python](xref:microsoft.quantum.install-qdk.overview.python#install-the-qsharp-python-package).
 
-## Installation
-
-Follow these steps to install Jupyter Notebook and the current version of the
-IQ# kernel, which powers the Q# Jupyter Notebook and Python experiences.
-
-1. Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or
-   [Anaconda](https://www.anaconda.com/products/individual#Downloads).
-1. Open an Anaconda Prompt.
-   - Or, if you prefer to use PowerShell or pwsh: open a shell, run `conda init
-     powershell`, then close and re-open the shell.
-1. Create and activate a new conda environment named `qsharp-env` with the
-   required packages (including Jupyter Notebook and IQ#) by running the
-   following commands:
-
-    ```
-    conda create -n qsharp-env -c quantum-engineering qsharp notebook
-
-    conda activate qsharp-env
-    ```
-
-1. Run `python -c "import qsharp"` from the same terminal to verify your
-   installation and populate your local package cache with all of the required QDK
-   components.
-
-You are now set up to use Python and Q# integration to run
-quantum programs on Azure Quantum.
+Follow the installation steps in the provided link to install Python and
+the current version of the IQ# kernel, which powers the Q# Jupyter Notebook and
+Python experiences.
 
 ## Quantum computing with Q# and Python
 

--- a/articles/install-command-line-qdk.md
+++ b/articles/install-command-line-qdk.md
@@ -26,12 +26,14 @@ While you can build Q# applications in any IDE, we recommend using Visual Studio
 > [!IMPORTANT]
 > If you are working on Linux, you may encounter a missing dependency depending on your particular distribution and installation method (e.g. certain Docker images). Please make sure that the `libgomp` library is installed on your system, as the GNU OpenMP support library is required by the quantum simulator of the QDK. On Ubuntu, you can do so by running `sudo apt install libgomp1`, or `yum install libgomp` on CentOS. For other distributions, please refer to your particular package manager.
 
-### To configure for VS Code:
+Configure the QDK for your preferred environment from one of the following options:
+
+### [VS Code](#tab/tabid-vscode)
 
 1. Download and install [VS Code](https://code.visualstudio.com/download) 1.52.0 or greater (Windows, Linux and Mac).
 2. Install the [QDK for VS Code](https://marketplace.visualstudio.com/items?itemName=quantum.quantum-devkit-vscode).
 
-### To configure for Visual Studio (Windows only):
+### [Visual Studio (Windows only)](#tab/tabid-vs)
 
 1. Download and install [Visual Studio](https://visualstudio.microsoft.com/downloads/) 16.3 or greater, with the .NET Core cross-platform development workload enabled.
 2. Download and install the [QDK](https://marketplace.visualstudio.com/items?itemName=quantum.DevKit).
@@ -39,7 +41,7 @@ While you can build Q# applications in any IDE, we recommend using Visual Studio
 > [!NOTE]
 > Although there is Visual Studio for Mac, the QDK extension is only compatible with Visual Studio for Windows.
 
-### To configure for another environment:
+### [Other editors with the command prompt](#tab/tabid-cmdline)
 
 1. Enter the following at the command prompt
 
@@ -47,7 +49,7 @@ While you can build Q# applications in any IDE, we recommend using Visual Studio
 dotnet new -i Microsoft.Quantum.ProjectTemplates
 ```
 
-## Develop with Q#
+## Develop with Q\#
 
 Follow the instructions on the tab corresponding to your development environment.
 
@@ -73,7 +75,7 @@ To run the application:
 > [!NOTE]
 > Workspaces with multiple root folders are not currently supported by the VS Code Q# extension. If you have multiple projects within one VS Code workspace, all projects need to be contained within the same root folder.
 
-### [Visual Studio](#tab/tabid-vs)
+### [Visual Studio (Windows only)](#tab/tabid-vs)
 
 Verify your Visual Studio installation by creating a Q# `Hello World` application.
 
@@ -82,7 +84,6 @@ To create a new Q# application:
 1. Open Visual Studio and click **File** -> **New** -> **Project**.
 2. Type `Q#` in the search box, select **Q# Application** and click **Next**.
 3. Enter a name and location for your application and click **Create**.
-
 
 Inspect the project. You should see a source file named `Program.qs`, which is a Q# program that defines a simple operation to print a message to the console.
 
@@ -110,7 +111,7 @@ Verify your installation by creating a Q# `Hello World` application.
     cd runSayHello
     ```
 
-    This directory should now contain a file `Program.qs`, which is a Q# program that defines a simple operation to print a message to the console. You can modfiy this template with a text editor and overwrite it with your own quantum applications. 
+    This directory should now contain a file `Program.qs`, which is a Q# program that defines a simple operation to print a message to the console. You can modfiy this template with a text editor and overwrite it with your own quantum applications.
 
 1. Run the program:
 

--- a/articles/install-jupyter-qdk.md
+++ b/articles/install-jupyter-qdk.md
@@ -23,21 +23,30 @@ IQ# (pronounced i-q-sharp) is an extension primarily used by Jupyter and Python 
 
 ### [Install using conda (recommended)](#tab/tabid-conda)
 
-1. Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual#Downloads). **Note:** 64-bit installation required.
+1. Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual#Downloads). Consult their [installation guide](https://docs.conda.io/projects/conda/en/latest/user-guide/install/) if you are unsure about any steps. **Note:** 64-bit installation required.
 
-1. Open an Anaconda Prompt.
+1. Initialize conda for your preferred shell with the `conda init` command. The steps below are tailored to your operating system:
 
-   - Or, if you prefer to use PowerShell or pwsh: open a shell, run `conda init powershell`, then close and re-open the shell.
+    **(Windows)** Open an Anaconda Prompt by searching for it in the start menu. Then run the initialization command for your shell, e.g. `conda init powershell cmd.exe` will set up both the Windows PowerShell and Command Prompt for you. You can then close this prompt.
 
-1. Create and activate a new conda environment named `qsharp-env` with the required packages (including Jupyter Notebook and IQ#) by running the following commands:
+    > [!IMPORTANT]
+    > To work with PowerShell, conda will configure a startup script to run whenever you launch a PowerShell instance. By default, the script's execution will be blocked on Windows, and requires modifying the PowerShell execution policy with the following command (executed from within PowerShell):
+    >
+    > ```powershell
+    > Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
+    > ```
 
-    ```
+    **(Linux)** If haven't done so during installation, you can still initialize conda now. Open a terminal and navigate to the `bin` directory inside your selected install location (e.g. `/home/ubuntu/miniconda3/bin`). Then run the appropriate command for your shell, e.g. `./conda init bash`. Close your terminal for the changes to take effect.
+
+1. From a new terminal, create and activate a new conda environment named `qsharp-env` with the required packages (including Jupyter Notebook and IQ#) by running the following commands:
+
+    ```shell
     conda create -n qsharp-env -c quantum-engineering qsharp notebook
 
     conda activate qsharp-env
     ```
 
-1. Run `python -c "import qsharp"` from the same terminal to verify your installation and populate your local package cache with all required QDK components.
+1. Finally, run `python -c "import qsharp"` to verify your installation and populate your local package cache with all required QDK components.
 
 ### [Install using .NET CLI (advanced)](#tab/tabid-dotnetcli)
 
@@ -47,25 +56,29 @@ IQ# (pronounced i-q-sharp) is an extension primarily used by Jupyter and Python 
     - [Jupyter Notebook](https://jupyter.readthedocs.io/en/latest/install.html)
     - [.NET Core SDK 3.1](https://dotnet.microsoft.com/download/dotnet-core/3.1)
 
-1. Install the `Microsoft.Quantum.IQSharp` package.
+1. Install IQ# via the .NET `Microsoft.Quantum.IQSharp` package.
 
     ```dotnetcli
     dotnet tool install -g Microsoft.Quantum.IQSharp
     dotnet iqsharp install
     ```
 
-> [!NOTE]
-> If you get an error during the `dotnet iqsharp install` step, open a new terminal window and try again.
-> If this still doesn't work, try locating the installed `dotnet-iqsharp` tool (on Windows, `dotnet-iqsharp.exe`) and running:
-> ```
-> /path/to/dotnet-iqsharp install --user --path-to-tool="/path/to/dotnet-iqsharp"
-> ```
-> where `/path/to/dotnet-iqsharp` should be replaced by the absolute path to the `dotnet-iqsharp` tool in your file system.
-> Typically this will be under `.dotnet/tools` in your user profile folder.
+    > [!NOTE]
+    > If you encounter a permission error in Linux, install the IQ# kernel in user mode instead with `dotnet iqsharp install --user`.
+
+    > [!NOTE]
+    > If you encounter an error and you just installed .NET, you won't be able to run the `dotnet iqsharp install` command immediately. Instead, under Windows, open a new terminal window and try again. Under Linux, log out of your session and log back in to try again.
+    > If this still doesn't work, try locating the installed `dotnet-iqsharp` tool (on Windows, `dotnet-iqsharp.exe`) and running:
+    >
+    > ```dotnetcli
+    > /path/to/dotnet-iqsharp install --user --path-to-tool="/path/to/dotnet-iqsharp"
+    > ```
+    >
+    > where `/path/to/dotnet-iqsharp` should be replaced by the absolute path to the `dotnet-iqsharp` tool in your file system. Typically this will be under `.dotnet/tools` in your user profile folder.
 
 ***
 
-That's it! You now have the IQ# kernel for Jupyter, which provides the core functionality for compiling and running Q# operations from Q# Jupyter Notebooks.
+That's it! You now have the IQ# kernel for Jupyter, allowing you to compile and run Q# operations from Q# Jupyter Notebooks.
 
 ## Create your first Q# notebook
 
@@ -73,7 +86,7 @@ Now you are ready to verify your Q# Jupyter Notebook installation by writing and
 
 1. From the environment you created during installation (that is, either the conda environment you created, or the Python environment where you installed Jupyter), run the following command to start the Jupyter Notebook server:
 
-    ```
+    ```shell
     jupyter notebook
     ```
 

--- a/articles/install-python-qdk.md
+++ b/articles/install-python-qdk.md
@@ -17,6 +17,8 @@ Learn how to install the Quantum Development Kit (QDK) to develop Python host pr
 
 ## Install the `qsharp` Python package
 
+The `qsharp` Python package, which includes the IQ# kernel, contains the necessary functionality for compiling and simulating Q# operations from a regular Python program.
+
 ### [Install using conda (recommended)](#tab/tabid-conda)
 
 1. Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual#Downloads). Consult their [installation guide](https://docs.conda.io/projects/conda/en/latest/user-guide/install/) if you are unsure about any steps. **Note:** 64-bit installation required.
@@ -80,7 +82,7 @@ Learn how to install the Quantum Development Kit (QDK) to develop Python host pr
 
 ***
 
-That's it! You now have both the `qsharp` Python package and the IQ# kernel for Jupyter, which provide the core functionality for compiling and running Q# operations from Python and allows you to use Q# Jupyter Notebooks.
+That's it! You now have both the `qsharp` Python package and the IQ# kernel for Jupyter, allowing you to compile and run Q# operations from Python and Q# Jupyter Notebooks.
 
 ## Choose your IDE
 

--- a/articles/install-python-qdk.md
+++ b/articles/install-python-qdk.md
@@ -11,7 +11,7 @@ title: Develop with Q# and Python
 uid: microsoft.quantum.install-qdk.overview.python
 ---
 
-# Use the QDK for quantum computing with Q# and Python
+# Develop with Q# and Python
 
 Learn how to install the Quantum Development Kit (QDK) to develop Python host programs that call Q# operations.
 


### PR DESCRIPTION
Contains:

- `install-python-qdk.md`: Make article title same style as all other QDK install articles:
   *Use the QDK for quantum computing with Q# and Python* -> *Develop with Q# and Python*
   @Bradben is this ok vis-a-vis changing an article title and its implications?

- `install-jupyter-qdk.md`: Copy improved instructions from the recent PR #160 to this article as well.

- `install-command-line-qdk.md`: Installation part of the article was using regular headers to provide instructions for different environments, but rest of the article uses tabs for each environment. Convert installation subheadings to tabs.

- `how-to-submit-jobs-with-jupyter-notebooks.md`/`with-python.md`: Articles contained duplicate installation instructions for the QDK which have become outdated. Link to the relevant Docs articles to avoid this in the future.