### PR TITLE
Update to Population Annealing Parameters & A bunch of consistency changes

### DIFF
--- a/articles/optimization-input-formats.md
+++ b/articles/optimization-input-formats.md
@@ -13,6 +13,7 @@ uid: microsoft.quantum.optimization.input-format
 # Input format for optimization problems
 
 This document explains how the parameters to optimization problems may be specified for all the different solvers. 
+All solvers set default values for their parameters but we strongly recommend setting them to values appropriate for your problem. Where there is a parameter-free solver available not setting any parameters will call the parameter-free version of that solver which will complete when there is sufficient convergence on a solution.
 
 ## Parallel Tempering
 <table>
@@ -108,9 +109,9 @@ This document explains how the parameters to optimization problems may be specif
     </thead>
     <tbody>
     <tr>
-        <td>step_limit</td>
+        <td>sweeps</td>
         <td>integer</td>
-        <td>Number of Monte Carlo steps. More steps will usually improve the solution if it has not yet found a global minimum.</td>
+        <td>Number of sweeps. More sweeps will usually improve the solution if it has not yet found a global minimum.</td>
     </tr>
     <tr>
         <td>beta</td>

--- a/articles/optimization-parallel-tempering.md
+++ b/articles/optimization-parallel-tempering.md
@@ -60,6 +60,15 @@ solver = ParallelTempering(workspace, timeout=100, seed=22)
 
 The parameter-free solver will return the parameters used in the result JSON. You can then use these parameters to solve similar problems (similar number of variables, terms, locality and similar coefficient scale) using the parametrized parallel tempering solver.
 
+Running the solver without any parameters also triggers the parameter-free version:
+
+```python
+from azure.quantum.optimization import ParallelTempering
+# Requires a workspace already created.
+# Not specifying any parameters runs the parameter-free version of the solver.
+solver = ParallelTempering(workspace)
+```
+
 ## Parametrized parallel tempering
 
 Parallel tempering with specified parameters is best used if you are already familiar with parallel tempering terminology (sweeps, betas) and/or have an idea of which parameter values you intend to use. **If this is your first time using parallel tempering for a problem, the parameter-free version is recommended.** Some of the parameters like `beta_start` and `beta_stop` are hard to estimate without a good starting point.

--- a/articles/optimization-parallel-tempering.md
+++ b/articles/optimization-parallel-tempering.md
@@ -48,7 +48,7 @@ The parameter-free solver will halt either on `timeout` (specified in seconds) o
 | Parameter Name | Description |
 |----------------|-------------|
 | `timeout` | Max execution time for the solver (in seconds). This is a best effort mechanism, so the solver may not stop immediately when the timeout is reached.|
-| `seed (optional)` | Seed value - used for reproducing results. |
+| `seed` (optional) | Seed value - used for reproducing results. |
 
 To create a parameter-free parallel tempering solver using the SDK:
 
@@ -80,7 +80,7 @@ Parallel tempering supports the following parameters:
 | `sweeps` | Number of sets of iterations to run over the variables of a problem. More sweeps will usually improve the solution (unless it is already at the global min).|
 | `replicas`  | The number of concurrent running copies for sampling. Each instance will start with a random configuration. We recommend this value to be no less than the number of cores available on the machine, in order to fully utilize the available compute power. Currently on Azure Quantum this should be no less than 72.|
 | `all_betas` | The list of beta values used in each replica for sampling. The number of beta values must equal the number of replicas, as each replica will be assigned one beta value from the list. These beta values control how the solver escapes optimization saddle points - the larger the beta values, the less likely the sampling process will be to jump out of a local optimum.|
-| `seed (optional)` | Seed value - used for reproducing results |
+| `seed` (optional) | Seed value - used for reproducing results |
 
 The larger the number of sweeps and replicas, the more likely the parallel tempering solver will be to find an optimal or near-optimal solution, however the solver will take longer to run.
 

--- a/articles/optimization-population-annealing.md
+++ b/articles/optimization-population-annealing.md
@@ -90,7 +90,7 @@ Population Annealing supports the following parameters:
 | `sweeps`             |10000      | Number of sweeps. More sweeps will usually improve the solution (unless it is already at the global minimum). |
 | `beta`                   | linear `0`..`5` | Annealing schedule (beta must be increasing) |
 | `population`             | _number of threads_ | The number of walkers in the population (must be positive). |
-| `seed (optional)`                  | _time based_    | Seed value - used for reproducing results. |
+| `seed` (optional)        | _time based_    | Seed value - used for reproducing results. |
 
 To create a parameterized Population Annealing solver for the CPU using the SDK:
 

--- a/articles/optimization-population-annealing.md
+++ b/articles/optimization-population-annealing.md
@@ -87,7 +87,7 @@ Population Annealing supports the following parameters:
 
 | Parameter Name           | Default Value   | Description |
 |--------------------------|-----------------|-------------|
-| `step_limit`             | _required_      | Number of Monte Carlo steps. More steps will usually improve the solution (unless it is already at the global minimum). |
+| `sweeps`             |10000      | Number of sweeps. More sweeps will usually improve the solution (unless it is already at the global minimum). |
 | `beta`                   | linear `0`..`5` | Annealing schedule (beta must be increasing) |
 | `population`             | _number of threads_ | The number of walkers in the population (must be positive). |
 | `seed` (optional)        | _time based_    | Seed value - used for reproducing results. |
@@ -97,5 +97,14 @@ To create a parameterized Population Annealing solver for the CPU using the SDK:
 ```python
 from azure.quantum.optimization import PopulationAnnealing, RangeSchedule
 # Requires a workspace already created.
-solver = PopulationAnnealing(workspace, step_limit=200, beta=RangeSchedule("linear", 0, 5), population=128, seed=42)
+solver = PopulationAnnealing(workspace, sweeps=200, beta=RangeSchedule("linear", 0, 5), population=128, seed=42)
+```
+
+Running the solver without parameters will apply the default parameters shown in the table above:
+
+```python
+from azure.quantum.optimization import PopulationAnnealing, RangeSchedule
+# Requires a workspace already created
+# Running with default parameters
+solver = PopulationAnnealing(workspace)
 ```

--- a/articles/optimization-population-annealing.md
+++ b/articles/optimization-population-annealing.md
@@ -90,7 +90,7 @@ Population Annealing supports the following parameters:
 | `sweeps`             |10000      | Number of sweeps. More sweeps will usually improve the solution (unless it is already at the global minimum). |
 | `beta`                   | linear `0`..`5` | Annealing schedule (beta must be increasing) |
 | `population`             | _number of threads_ | The number of walkers in the population (must be positive). |
-| `seed`                   | _time based_    | Seed value - used for reproducing results. |
+| `seed (optional)`                  | _time based_    | Seed value - used for reproducing results. |
 
 To create a parameterized Population Annealing solver for the CPU using the SDK:
 

--- a/articles/optimization-population-annealing.md
+++ b/articles/optimization-population-annealing.md
@@ -90,7 +90,7 @@ Population Annealing supports the following parameters:
 | `sweeps`             |10000      | Number of sweeps. More sweeps will usually improve the solution (unless it is already at the global minimum). |
 | `beta`                   | linear `0`..`5` | Annealing schedule (beta must be increasing) |
 | `population`             | _number of threads_ | The number of walkers in the population (must be positive). |
-| `seed` (optional)        | _time based_    | Seed value - used for reproducing results. |
+| `seed`                   | _time based_    | Seed value - used for reproducing results. |
 
 To create a parameterized Population Annealing solver for the CPU using the SDK:
 
@@ -100,11 +100,4 @@ from azure.quantum.optimization import PopulationAnnealing, RangeSchedule
 solver = PopulationAnnealing(workspace, sweeps=200, beta=RangeSchedule("linear", 0, 5), population=128, seed=42)
 ```
 
-Running the solver without parameters will apply the default parameters shown in the table above:
-
-```python
-from azure.quantum.optimization import PopulationAnnealing, RangeSchedule
-# Requires a workspace already created
-# Running with default parameters
-solver = PopulationAnnealing(workspace)
-```
+Running the solver without parameters will apply the default parameters shown in the table above. These default values are subject to change and we strongly recommend setting the values based on your problem rather than using the defaults.

--- a/articles/optimization-quantum-monte-carlo.md
+++ b/articles/optimization-quantum-monte-carlo.md
@@ -51,5 +51,5 @@ To create a parameterized Quantum Monte Carlo solver using the SDK:
 ```python
 from azure.quantum.optimization import QuantumMonteCarlo
 # Requires a workspace to be already created
-solver = QuantumMonteCarlo(workspace, sweeps = 2, trotter_number = 10, restarts = 72, seed = 22, beta_start = 0.1, transverse_field_start = 10, transverse_field_stop = 0.1)
+solver = QuantumMonteCarlo(workspace, sweeps = 2, trotter_number = 10, restarts = 72, beta_start = 0.1, transverse_field_start = 10, transverse_field_stop = 0.1, seed = 22)
 ```

--- a/articles/optimization-quantum-monte-carlo.md
+++ b/articles/optimization-quantum-monte-carlo.md
@@ -44,6 +44,7 @@ Quantum Monte Carlo supports the following parameters:
 |`restarts`| The number of repeats of the annealing schedule to run. Each restart will start with a random configuration unless an initial configuration is supplied in the problem file. The restarts will be executed in parallel and split amongst the threads of the virtual machine. Recommended to set this value to at least 72.|
 |`beta_start`| Represents the temperature at which the annealing schedule is executed. This should be a value low enough to produce a feasible configuration. |
 |`transverse_field_start` & `transverse_field_stop`| Represents the starting and stopping values of the external field applied to the annealing schedule. A suitable value for these parameters will depend entirely on the problem and the magnitude of its changing moves. In general a non-zero and declining acceptance probability is sufficient.|
+|`seed` (optional)| Seed value - used for reproducing results. |
 
 To create a parameterized Quantum Monte Carlo solver using the SDK:
 

--- a/articles/optimization-simulated-annealing.md
+++ b/articles/optimization-simulated-annealing.md
@@ -44,7 +44,7 @@ The parameter-free solver will halt either on `timeout` (specified in seconds) o
 | Parameter Name | Description |
 |----------------|-------------|
 | `timeout` | Max execution time for the solver (in seconds). This is a best effort mechanism, so the solver may not stop immediately when the timeout is reached.|
-| `seed` | Seed value - used for reproducing results. |
+| `seed (optional)` | Seed value - used for reproducing results. |
 
 To create a parameter-free simulated annealing solver for the CPU platform using the SDK:
 

--- a/articles/optimization-simulated-annealing.md
+++ b/articles/optimization-simulated-annealing.md
@@ -46,8 +46,7 @@ The parameter-free solver will halt either on `timeout` (specified in seconds) o
 | `timeout` | Max execution time for the solver (in seconds). This is a best effort mechanism, so the solver may not stop immediately when the timeout is reached.|
 | `seed` | Seed value - used for reproducing results. |
 
-You can create a parameter-free simulated annealing solver using the Python SDK. 
-The below sample is for a CPU target.
+To create a parameter-free simulated annealing solver for the CPU platform using the SDK:
 
 ```python
 from azure.quantum.optimization import SimulatedAnnealing
@@ -79,7 +78,7 @@ Simulated annealing supports the following parameters:
 | `restarts`              | The number of repeats of the annealing schedule to run. Each restart will start with a random configuration **unless an initial configuration is supplied in the problem file.** The restarts will be executed in parallel and split amongst the threads of the VM. Recommended to set this value to at least 72.|
 | `seed (optional)`                 | Seed value - used for reproducing results |
 
-To create a parameterized simulated annealing solver with a CPU target use the following code: 
+To create a parameterized simulated annealing solver for the CPU platform using the SDK:
 
 ```python
 from azure.quantum.optimization import SimulatedAnnealing
@@ -115,7 +114,7 @@ FPGA simulated annealing uses the same parameters as the corresponding CPU solve
 
 It is also recommended to set the number of restarts to at least 216 if using the FPGA solver, as it can support a higher degree of parallelization.
 
-To create a simulated annealing solver for the FPGA using the SDK, simply specify the platform option as follows:
+To create a simulated annealing solver for the FPGA platform using the SDK, simply specify the platform option as follows:
 
 ```python
 from azure.quantum.optimization import SimulatedAnnealing, HardwarePlatform

--- a/articles/optimization-simulated-annealing.md
+++ b/articles/optimization-simulated-annealing.md
@@ -44,7 +44,7 @@ The parameter-free solver will halt either on `timeout` (specified in seconds) o
 | Parameter Name | Description |
 |----------------|-------------|
 | `timeout` | Max execution time for the solver (in seconds). This is a best effort mechanism, so the solver may not stop immediately when the timeout is reached.|
-| `seed (optional)` | Seed value - used for reproducing results. |
+| `seed` (optional) | Seed value - used for reproducing results. |
 
 To create a parameter-free simulated annealing solver for the CPU platform using the SDK:
 
@@ -76,7 +76,7 @@ Simulated annealing supports the following parameters:
 | `sweeps`       | Number of sets of iterations to run over the variables of a problem. More sweeps will usually improve the solution (unless it is already at the global min).|
 | `beta_start/beta_stop`  | Represents the starting and stopping betas of the annealing schedule. A suitable value for these parameters will depend entirely on the problem and the magnitude of its changing moves. In general a non-zero and declining acceptance probability is sufficient. |
 | `restarts`              | The number of repeats of the annealing schedule to run. Each restart will start with a random configuration **unless an initial configuration is supplied in the problem file.** The restarts will be executed in parallel and split amongst the threads of the VM. Recommended to set this value to at least 72.|
-| `seed (optional)`                 | Seed value - used for reproducing results |
+| `seed` (optional)                 | Seed value - used for reproducing results |
 
 To create a parameterized simulated annealing solver for the CPU platform using the SDK:
 

--- a/articles/optimization-simulated-annealing.md
+++ b/articles/optimization-simulated-annealing.md
@@ -22,7 +22,7 @@ When sweeping for a binary problem, each decision variable is "flipped" based on
 
 Simulated annealing in Azure Quantum supports:
 
-- Parameter-free mode and parametrized mode (with parameters)
+- Parameter-free mode and parameterized mode (with parameters)
 - Ising and PUBO input formats
 - CPU & FPGA hardware (see below for instructions on how to use both)
 
@@ -39,14 +39,15 @@ It is also a good algorithm for larger problems (thousands of variables).
 
 The parameter-free version of simulated annealing is recommended for new users, those who don't want to manually tune parameters (especially betas), and even as a starting point for further manual tuning. The main parameters to be tuned for this solver are the number of `sweeps`, `beta_start` and `beta_stop` (described in the next section).
 
-The parameter-free solver will halt either on `timeout` (specified in seconds) or when there is sufficient convergence on a solution.
+The parameter-free solver will halt either on `timeout` (specified in seconds) or when there is sufficient convergence on a solution. A seed can be supplied to reproduce results. 
 
 | Parameter Name | Description |
 |----------------|-------------|
 | `timeout` | Max execution time for the solver (in seconds). This is a best effort mechanism, so the solver may not stop immediately when the timeout is reached.|
-| `seed (optional)` | Seed value - used for reproducing results. |
+| `seed` | Seed value - used for reproducing results. |
 
-To create a parameter-free simulated annealing solver for the CPU using the SDK:
+You can create a parameter-free simulated annealing solver using the Python SDK. 
+The below sample is for a CPU target.
 
 ```python
 from azure.quantum.optimization import SimulatedAnnealing
@@ -54,9 +55,18 @@ from azure.quantum.optimization import SimulatedAnnealing
 solver = SimulatedAnnealing(workspace, timeout=100, seed=22)
 ```
 
-The parameter-free solver will return the parameters used in the result JSON. You can then use these parameters to solve similar problems (similar number of variables, terms, locality and similar coefficient scale) using the parametrized simulated annealing solver.
+The parameter-free solver will return the parameters used in the result JSON. You can then use these parameters to solve similar problems (similar number of variables, terms, locality and similar coefficient scale) using the parameterized simulated annealing solver.
 
-## Parametrized simulated annealing (CPU)
+Running the solver without any parameters also triggers the parameter-free version:
+
+```python
+from azure.quantum.optimization import SimulatedAnnealing
+# Requires a workspace already created.
+# Not specifying any parameters runs the parameter-free version of the solver.
+solver = SimulatedAnnealing(workspace)
+```
+
+## Parameterized simulated annealing (CPU)
 
 Simulated annealing with specified parameters is best used if you are already familiar with simulated annealing terminology (sweeps, betas) and/or have an idea of which parameter values you intend to use. **If this is your first time using simulated annealing for a problem, the parameter-free version is recommended.** Some of the parameters like `beta_start` and `beta_stop` are hard to estimate without a good starting point.
 
@@ -69,7 +79,7 @@ Simulated annealing supports the following parameters:
 | `restarts`              | The number of repeats of the annealing schedule to run. Each restart will start with a random configuration **unless an initial configuration is supplied in the problem file.** The restarts will be executed in parallel and split amongst the threads of the VM. Recommended to set this value to at least 72.|
 | `seed (optional)`                 | Seed value - used for reproducing results |
 
-To create a parametrized simulated annealing solver for the CPU using the SDK:
+To create a parameterized simulated annealing solver with a CPU target use the following code: 
 
 ```python
 from azure.quantum.optimization import SimulatedAnnealing
@@ -113,7 +123,9 @@ from azure.quantum.optimization import SimulatedAnnealing, HardwarePlatform
 solver = SimulatedAnnealing(workspace, timeout=100, seed=22, platform=HardwarePlatform.FPGA)
 ```
 
-For the parametrized version:
+The `timeout` and `seed` parameters are optional.
+
+For the parameterized version:
 
 ```python
 from azure.quantum.optimization import SimulatedAnnealing, HardwarePlatform

--- a/articles/optimization-substochastic-monte-carlo.md
+++ b/articles/optimization-substochastic-monte-carlo.md
@@ -94,7 +94,7 @@ Substochastic Monte Carlo supports the following parameters:
 | `target_population`      | _number of threads_ | The number of walkers in the population (should be greater-equal 8). |
 | `alpha`                  | linear `1`..`0` | Schedule for the stepping chance (must be decreasing, i.e. `alpha.initial > alpha.final`). |
 | `beta`                   | linear `0`..`5` | Schedule for the resampling factor (must be increasing, i.e. `beta.initial < beta.final`). |
-| `seed` (optional)        | _time based_    | Seed value - used for reproducing results. |
+| `seed (optional)`        | _time based_    | Seed value - used for reproducing results. |
 
 To create a parameterized Substochastic Monte Carlo solver for the CPU using the SDK:
 

--- a/articles/optimization-substochastic-monte-carlo.md
+++ b/articles/optimization-substochastic-monte-carlo.md
@@ -94,7 +94,7 @@ Substochastic Monte Carlo supports the following parameters:
 | `target_population`      | _number of threads_ | The number of walkers in the population (should be greater-equal 8). |
 | `alpha`                  | linear `1`..`0` | Schedule for the stepping chance (must be decreasing, i.e. `alpha.initial > alpha.final`). |
 | `beta`                   | linear `0`..`5` | Schedule for the resampling factor (must be increasing, i.e. `beta.initial < beta.final`). |
-| `seed (optional)`        | _time based_    | Seed value - used for reproducing results. |
+| `seed` (optional)        | _time based_    | Seed value - used for reproducing results. |
 
 To create a parameterized Substochastic Monte Carlo solver for the CPU using the SDK:
 

--- a/articles/optimization-substochastic-monte-carlo.md
+++ b/articles/optimization-substochastic-monte-carlo.md
@@ -90,7 +90,7 @@ Substochastic Monte Carlo supports the following parameters:
 
 | Parameter Name           | Default Value   | Description |
 |--------------------------|-----------------|-------------|
-| `step_limit`             | _required_      | Number of monte carlo steps. More steps will usually improve the solution (unless it is already at the global minimum). |
+| `step_limit`             | 10000      | Number of monte carlo steps. More steps will usually improve the solution (unless it is already at the global minimum). |
 | `target_population`      | _number of threads_ | The number of walkers in the population (should be greater-equal 8). |
 | `alpha`                  | linear `1`..`0` | Schedule for the stepping chance (must be decreasing, i.e. `alpha.initial > alpha.final`). |
 | `beta`                   | linear `0`..`5` | Schedule for the resampling factor (must be increasing, i.e. `beta.initial < beta.final`). |
@@ -102,4 +102,13 @@ To create a parameterized Substochastic Monte Carlo solver for the CPU using the
 from azure.quantum.optimization import SubstochasticMonteCarlo, RangeSchedule
 # Requires a workspace already created.
 solver = SubstochasticMonteCarlo(workspace, step_limit=10000, target_population=64, beta=RangeSchedule("linear", 0, 5), seed=42)
+```
+
+Running the solver without parameters will apply the default parameters shown in the table above:
+
+```python
+from azure.quantum.optimization import SubstochasticMonteCarlo, RangeSchedule
+# Requires a workspace already created
+# Running with default parameters
+solver = SubstochasticMonteCarlo(workspace)
 ```

--- a/articles/optimization-substochastic-monte-carlo.md
+++ b/articles/optimization-substochastic-monte-carlo.md
@@ -104,11 +104,4 @@ from azure.quantum.optimization import SubstochasticMonteCarlo, RangeSchedule
 solver = SubstochasticMonteCarlo(workspace, step_limit=10000, target_population=64, beta=RangeSchedule("linear", 0, 5), seed=42)
 ```
 
-Running the solver without parameters will apply the default parameters shown in the table above:
-
-```python
-from azure.quantum.optimization import SubstochasticMonteCarlo, RangeSchedule
-# Requires a workspace already created
-# Running with default parameters
-solver = SubstochasticMonteCarlo(workspace)
-```
+Running the solver without parameters will apply the default parameters shown in the table above. These default values are subject to change and we strongly recommend setting the values based on your problem rather than using the defaults.

--- a/articles/optimization-tabu-search.md
+++ b/articles/optimization-tabu-search.md
@@ -47,7 +47,7 @@ The parameter-free solver will halt either on `timeout` (specified in seconds) o
 | Parameter Name | Description |
 |----------------|-------------|
 | `timeout` | Max execution time for the solver (in seconds). This is a best effort mechanism, so the solver may not stop immediately when the timeout is reached.|
-| `seed (optional)` | Seed value - used for reproducing results. |
+| `seed` | Seed value - used for reproducing results. |
 
 To create a parameter-free Tabu solver using the SDK:
 
@@ -58,6 +58,15 @@ solver = Tabu(workspace, timeout=100, seed=22)
 ```
 
 The parameter-free solver will return the parameters used in the result JSON. You can then use these parameters to solve similar problems (similar number of variables, terms, locality and similar coefficient scale) using the parametrized tabu search solver.
+
+Running the solver without any parameters also triggers the parameter-free version:
+
+```python
+from azure.quantum.optimization import Tabu
+# Requires a workspace already created.
+# Not specifying any parameters runs the parameter-free version of the solver.
+solver = Tabu(workspace)
+```
 
 ## Parameterized tabu search
 

--- a/articles/optimization-tabu-search.md
+++ b/articles/optimization-tabu-search.md
@@ -47,7 +47,7 @@ The parameter-free solver will halt either on `timeout` (specified in seconds) o
 | Parameter Name | Description |
 |----------------|-------------|
 | `timeout` | Max execution time for the solver (in seconds). This is a best effort mechanism, so the solver may not stop immediately when the timeout is reached.|
-| `seed (optional)` | Seed value - used for reproducing results. |
+| `seed` (optional) | Seed value - used for reproducing results. |
 
 To create a parameter-free Tabu solver using the SDK:
 
@@ -79,8 +79,8 @@ Tabu search supports the following parameters:
 | `sweeps`       | Number of sets of iterations to run over the variables of a problem. The more sweeps will usually always improve the solution (unless it is already at the global min).|
 | `tabu_tenure`  | Tenure of the tabu list in moves. Describes how many moves a variable stays on the tabu list once it has been made. This value is recommended to be between 1 and the number of variables to have any impact. This will be the main tuneable parameter that will determine the quality of the solution. A good starting point is 20. |
 | `restarts`  | The number of repeated instances to run the solver. Each instance will start with a random configuration **unless an initial configuration is supplied in the problem file**. This is recommended to be at least 72 to fully utilize machine capabilities. |
-| `replicas (deprecated)`  | The number of concurrent solvers to initialize. This parameter will now default to the number of available processors on the machine, and is no longer accepting input. |
-| `seed (optional)` | Seed value - used for reproducing results |
+| `replicas` (deprecated)  | The number of concurrent solvers to initialize. This parameter will now default to the number of available processors on the machine, and is no longer accepting input. |
+| `seed` (optional) | Seed value - used for reproducing results |
 
 To create a parametrized Tabu solver using the SDK:
 

--- a/articles/optimization-tabu-search.md
+++ b/articles/optimization-tabu-search.md
@@ -47,7 +47,7 @@ The parameter-free solver will halt either on `timeout` (specified in seconds) o
 | Parameter Name | Description |
 |----------------|-------------|
 | `timeout` | Max execution time for the solver (in seconds). This is a best effort mechanism, so the solver may not stop immediately when the timeout is reached.|
-| `seed` | Seed value - used for reproducing results. |
+| `seed (optional)` | Seed value - used for reproducing results. |
 
 To create a parameter-free Tabu solver using the SDK:
 


### PR DESCRIPTION
- Added a note that all solvers set default values
- Added clarification that all solvers run without parameters (using default variables) even if there isn't a parameter-free version
- Added clarification as to why we don't recommend that unless there is a parameter-free version
- Added seed parameter to QMC
- Moved parameter order for QMC
- Population Annealing: changed step_limit to sweeps which is the correct parameter
- Consistency changes around how `sweep` and `replicas` is shown in parameter table