### PR TITLE
Add information about Azure Quantum hardware target availability

### DIFF
--- a/articles/overview-azure-quantum.md
+++ b/articles/overview-azure-quantum.md
@@ -15,15 +15,16 @@ uid: microsoft.quantum.azure-quantum-overview
 Azure Quantum is a Microsoft Azure service that you can use to run quantum computing programs or solve optimization problems in the cloud. Using the Azure Quantum tools and SDKs, you can create quantum programs and run them against different quantum simulators and machines.
 
 ![alt_text=Infographic presenting the Azure Quantum service, consisting of quantum computing and optimization services.](./media/azure-quantum-infographic.png)
+
 ## Quantum computing
 
 Azure Quantum service offers you access to different providers of quantum computing devices and enables you to run your Q# quantum programs in real hardware. [Q#](xref:microsoft.quantum.overview.q-sharp) is a Microsoft’s open-source programming language for developing and running your quantum algorithms. Azure Quantum also offers the option to run algorithms in simulated quantum computers to test your code. To learn more about quantum computers and quantum algorithms see [Introduction to quantum computing](xref:microsoft.quantum.overview.qdk-overview).
 
-Azure Quantum provides access to trapped ion devices through the providers **IonQ** and **Honeywell.** 
+Azure Quantum provides access to trapped ion devices through the providers **IonQ** and **Honeywell**.
 
 ## Optimization
 
-Azure Quantum gives you access to a broad set of state-of-the-art optimization algorithms developed by Microsoft and its partners. You can use classic optimization algorithms, included some inspired by standard physics, as well as quantum-inspired optimization algorithms (QIO). 
+Azure Quantum gives you access to a broad set of state-of-the-art optimization algorithms developed by Microsoft and its partners. You can use classic optimization algorithms, included some inspired by standard physics, as well as quantum-inspired optimization algorithms (QIO).
 
 QIO uses algorithms that are based on quantum principles for increased speed and accuracy. Azure Quantum supports QIO to help developers leverage the power of new quantum techniques today without waiting for quantum hardware.
 
@@ -35,7 +36,7 @@ You use the Azure Quantum service by adding an Azure Quantum workspace resource 
 
 ## Providers and targets
 
-Another property configured in the workspace is the **provider** that you want to use to run programs in that workspace. A single provider may expose one or more **targets**, which can be quantum hardware or simulators, and are ultimately responsible for running your program. The complete list of targets can be found [here](xref:microsoft.quantum.reference.target.list).
+Another property configured in the workspace is the **provider** that you want to use to run programs in that workspace. A single provider may expose one or more **targets**, which can be quantum hardware or simulators, and are ultimately responsible for running your program. The complete list of targets can be found in the [quantum computing providers](xref:microsoft.quantum.reference.qc-target-list) and [optimization providers](xref:microsoft.quantum.reference.qio-target-list).
 
 By default, Azure Quantum adds the Microsoft QIO provider to every workspace, and you can add other providers when you create the workspace or any time afterward. For more information, see the [Microsoft QIO provider](xref:microsoft.quantum.optimization.providers.microsoft.qio).
 

--- a/articles/provider-honeywell.md
+++ b/articles/provider-honeywell.md
@@ -23,6 +23,16 @@ The following targets are available from this provider:
 - [Honeywell System Model H0](#honeywell-system-model-h0)
 - [Honeywell System Model H1](#honeywell-system-model-h1)
 
+### Target Availability
+
+A target's status indicates its current ability to process jobs. The possible states of a target include:
+
+- **Available**: The target is processing jobs at a normal rate.
+- **Degraded**: The target is currently processing jobs at a slower rate than usual.
+- **Unavailable**: The target currently does not process jobs.
+
+Current status information may be retrieved from the *Providers* tab of a workspace on the [Azure Portal](https://portal.azure.com).
+
 ### API Validator
 
 Tool to verify proper syntax and compilation completion. Full stack is exercised with the exception of the actual quantum operations. Assuming no bugs, all zeros are returned in the proper data structure.
@@ -32,7 +42,7 @@ Tool to verify proper syntax and compilation completion. Full stack is exercised
 - Target ID: `honeywell.hqs-lt-1.0-apival`
 - Target Execution Profile: [Basic Measurement Feedback](xref:microsoft.quantum.concepts.targets)
 
-Billing information:  No charge for usage. 
+Billing information:  No charge for usage.
 
 ### Honeywell System Model H0
 
@@ -61,8 +71,8 @@ $$
 
 where:
 
-- $N_{1q}$ is the number of one-qubit operations in a circuit. 
-- $N_{2q}$ is the number of native two-qubit operations in a circuit. Native gate is equivalent to CNOT up to several one-qubit gates.  
+- $N_{1q}$ is the number of one-qubit operations in a circuit.
+- $N_{2q}$ is the number of native two-qubit operations in a circuit. Native gate is equivalent to CNOT up to several one-qubit gates.
 - $N_{m}$ is the number of state preparation and measurement (SPAM) operations in a circuit including initial implicit state preparation and any intermediate and final measurements and state resets.
 - $C$ is the shot count.
 
@@ -70,8 +80,8 @@ where:
 
 - Trapped-ion based quantum computer with laser based gates
 - QCCD architecture with linear trap and two parallel operation zones
-- 6 physical qubits, fully connected  
-- Typical limiting fidelity >99.2% (two-qubit fidelity)  
+- 6 physical qubits, fully connected
+- Typical limiting fidelity >99.2% (two-qubit fidelity)
 - Coherence Time (T2) ~2 sec
 - Ability to perform mid-circuit measurement and qubit reuse
 - High-resolution rotations (> $\pi$/500)
@@ -81,19 +91,19 @@ where:
 
 ### Honeywell System Model H1
 
-Honeywell Quantum Solutions' Quantum Computer, System Model H1   
+Honeywell Quantum Solutions' Quantum Computer, System Model H1
 
 - Job type: `Quantum Program`
 - Data Format: `honeywell.openqasm.v1`
-- Target ID: `honeywell.hqs-lt-s1`  
+- Target ID: `honeywell.hqs-lt-s1`
 - Target Execution Profile: [Basic Measurement Feedback](xref:microsoft.quantum.concepts.targets)
 
 Billing information:
 
-- **Standard Subscription:**  
-Subscription plan with two 4-hour sessions of dedicated access, with unrestricted, queued access for the remainder of the month, based on system availability.  
-- **Premium Subscription:**  
-Subscription plan with four 4-hour sessions of dedicated access, with unrestricted, queued access for the remainder of the month, based on system availability.  
+- **Standard Subscription:**
+Subscription plan with two 4-hour sessions of dedicated access, with unrestricted, queued access for the remainder of the month, based on system availability.
+- **Premium Subscription:**
+Subscription plan with four 4-hour sessions of dedicated access, with unrestricted, queued access for the remainder of the month, based on system availability.
 
 #### Technical Specifications
 


### PR DESCRIPTION
@Mobius5150 I was debating whether to include this in a general Azure Quantum article or whether it is specific to Honeywell targets (since we only discussed it in the context of Honeywell).