### PR TITLE
Remove references to h0

### DIFF
--- a/articles/provider-honeywell.md
+++ b/articles/provider-honeywell.md
@@ -20,7 +20,6 @@ uid: microsoft.quantum.providers.honeywell
 The following targets are available from this provider:
 
 - [API Validator](#api-validator)
-- [Honeywell System Model H0](#honeywell-system-model-h0)
 - [Honeywell System Model H1](#honeywell-system-model-h1)
 
 ### Target Availability
@@ -44,27 +43,21 @@ Tool to verify proper syntax and compilation completion. Full stack is exercised
 
 Billing information:  No charge for usage.
 
-### Honeywell System Model H0
+### Honeywell System Model H1
 
-Honeywell Quantum Solutions' Quantum Computer, System Model H0
+Honeywell Quantum Solutions' Quantum Computer, System Model H1
 
 - Job type: `Quantum Program`
 - Data Format: `honeywell.openqasm.v1`
-- Target ID: `honeywell.hqs-lt-1.0`
+- Target ID: `honeywell.hqs-lt-s1`
 - Target Execution Profile: [Basic Measurement Feedback](xref:microsoft.quantum.concepts.targets)
 
 Billing information:
 
-- Priced by Honeywell Quantum Credits (see below).
-- Fee per hour for reserved (exclusive use) time.
-
-| Parameter Name | Type     | Required | Description |
-|----------------|----------|----------|-------------|
-| `count`   | int  | No | Number of experimental shots. Defaults to 1. |
-| `options` | list | No | Compiler options. Only one option currently supported: `no-opt` to disable all optimization |
-
-> [!IMPORTANT]
-> The default shot count shown in the table is a provider default. Submitting jobs without an explicit shot count through any of the Azure Quantum SDKs or the CLI will set this value to 500.
+- **Standard Subscription:**
+Monthly subscription plan with 10K Honeywell quantum credits (HQCs) / month, available through queue.
+- **Premium Subscription:**
+Monthly subscription plan with 17K Honeywell quantum credits (HQCs) / month, available through queue.
 
 The following equation defines how circuits are translated into Honeywell Quantum Credits (HQCs):
 
@@ -78,35 +71,6 @@ where:
 - $N_{2q}$ is the number of native two-qubit operations in a circuit. Native gate is equivalent to CNOT up to several one-qubit gates.
 - $N_{m}$ is the number of state preparation and measurement (SPAM) operations in a circuit including initial implicit state preparation and any intermediate and final measurements and state resets.
 - $C$ is the shot count.
-
-#### Technical Specifications
-
-- Trapped-ion based quantum computer with laser based gates
-- QCCD architecture with linear trap and two parallel operation zones
-- 6 physical qubits, fully connected
-- Typical limiting fidelity >99.2% (two-qubit fidelity)
-- Coherence Time (T2) ~2 sec
-- Ability to perform mid-circuit measurement and qubit reuse
-- High-resolution rotations (> $\pi$/500)
-- Native Gate set:
-  - single-qubit rotations
-  - two-qubit ZZ-gates
-
-### Honeywell System Model H1
-
-Honeywell Quantum Solutions' Quantum Computer, System Model H1
-
-- Job type: `Quantum Program`
-- Data Format: `honeywell.openqasm.v1`
-- Target ID: `honeywell.hqs-lt-s1`
-- Target Execution Profile: [Basic Measurement Feedback](xref:microsoft.quantum.concepts.targets)
-
-Billing information:
-
-- **Standard Subscription:**
-Subscription plan with two 4-hour sessions of dedicated access, with unrestricted, queued access for the remainder of the month, based on system availability.
-- **Premium Subscription:**
-Subscription plan with four 4-hour sessions of dedicated access, with unrestricted, queued access for the remainder of the month, based on system availability.
 
 #### Technical Specifications
 

--- a/articles/quickstart-honeywell.md
+++ b/articles/quickstart-honeywell.md
@@ -107,7 +107,7 @@ Next, we'll open up Visual Studio Code and get create a Q# Project.
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <ExecutionTarget>honeywell.hqs-lt-1.0</ExecutionTarget>
+    <ExecutionTarget>honeywell.hqs-lt-s1</ExecutionTarget>
   </PropertyGroup>
 </Project>
 ```
@@ -174,8 +174,8 @@ Next, we'll prepare your environment to run the program against the workspace yo
    ```output
    Provider    Target-id                                       Current Availability  Average Queue Time
    ----------  ----------------------------------------------  --------------------  --------------------
-   honeywell   honeywell.hqs-lt-1.0                            Available             0
-   honeywell   honeywell.hqs-lt-1.0-apival                     Available             0
+   honeywell   honeywell.hqs-lt-s1                             Available             0
+   honeywell   honeywell.hqs-lt-s1-apival                      Available             0
    ```
 
     > [!NOTE]
@@ -190,13 +190,13 @@ To run the program on hardware, we'll use the asynchronous job submission comman
 is complete. We recommend this pattern for running against hardware, because you may need to wait a while for your job to finish. To get an idea of how long you can run `az quantum target list -o table` as described above.
 
    ```azurecli
-   az quantum job submit --target-id honeywell.hqs-lt-1.0 -o table
+   az quantum job submit --target-id honeywell.hqs-lt-s1 -o table
    ```
 
    ```output
    Name        Id                                    Status    Target                Submission time
    ----------  ------------------------------------  --------  --------              ---------------------------------
-   QuantumRNG  b4d17c63-2119-4d92-91d9-c18d1a07e08f  Waiting   honeywell.hqs-lt-1.0  2020-01-12T22:41:27.8855301+00:00
+   QuantumRNG  b4d17c63-2119-4d92-91d9-c18d1a07e08f  Waiting   honeywell.hqs-lt-s1   2020-01-12T22:41:27.8855301+00:00
    ```
 
 The table above shows that your job has been submitted and is waiting for its turn to run. To check on the status, use the `az quantum job show` command, being sure to replace the `job-id` parameter with the Id output by the previous command:
@@ -208,7 +208,7 @@ The table above shows that your job has been submitted and is waiting for its tu
    ```output
    Name        Id                                    Status    Target    Submission time
    ----------  ------------------------------------  --------  --------  ---------------------------------
-   QuantumRNG  b4d17c63-2119-4d92-91d9-c18d1a07e08f  Waiting   honeywell.hqs-lt-1.0  2020-10-22T22:41:27.8855301+00:00 
+   QuantumRNG  b4d17c63-2119-4d92-91d9-c18d1a07e08f  Waiting   honeywell.hqs-lt-s1  2020-10-22T22:41:27.8855301+00:00 
    ```
 
 Eventually, you will see the `Status` in the above table change to `Succeeded`. Once that's done you can get the results from the job by running `az quantum job output`:


### PR DESCRIPTION
Honeywell has discontinued their H0 and updated the access plans for H1.