### PR TITLE
Use new SDK package name on standard library page

### DIFF
--- a/articles/user-guide/libraries/standard/index.md
+++ b/articles/user-guide/libraries/standard/index.md
@@ -14,8 +14,7 @@ uid: microsoft.quantum.libraries.overview.standard.intro
 # Introduction to the Q# Standard Libraries
 
 Q# is supported by a range of different useful operations, functions, and user-defined types that comprise the Q# *standard libraries*.
-The [`Microsoft.Quantum.Development.Kit` NuGet package](https://www.nuget.org/packages/microsoft.quantum.development.kit) installed during [installation and validation](xref:microsoft.quantum.install-qdk.overview) provides the Q# compiler, and parts of the standard library that are implemented by the target machines.
-The [`Microsoft.Quantum.Standard` package](https://www.nuget.org/packages/microsoft.quantum.standard) provides the portion of the Q# standard libraries that are portable across target machines.
+The [`Microsoft.Quantum.Sdk` NuGet package](https://www.nuget.org/packages/Microsoft.Quantum.Sdk/) installed during [installation and validation](xref:microsoft.quantum.install-qdk.overview) automatically provides the Q# standard library.
 
 The symbols defined by the Q# standard libraries are defined in much greater and more exhaustive detail in the [API documentation](xref:microsoft.quantum.apiref-intro).
 


### PR DESCRIPTION
This resolves #281 by updating the package name from `Microsoft.Quantum.Development.Kit` to `Microsoft.Quantum.Sdk`.

I also simplified the paragraph so that it no longer refers to target-specific and target-agnostic parts of the library, since I'm not sure that the distinction is important - the `Microsoft.Quantum.Sdk` package automatically includes everything that is necessary.