### PR TITLE
Use -> using for C# snippets

### DIFF
--- a/articles/tutorial-qdk-qubit-level-program.md
+++ b/articles/tutorial-qdk-qubit-level-program.md
@@ -615,7 +615,7 @@ namespace NamespaceQFT
     {
         static void Main(string[] args)
         {
-            using var qsim = new QuantumSimulator()
+            using (var qsim = new QuantumSimulator())
             {
                 var measurementResult = Perform3QubitQFT.Run(qsim).Result;
                 System.Console.WriteLine(

--- a/articles/tutorial-qdk-qubit-level-program.md
+++ b/articles/tutorial-qdk-qubit-level-program.md
@@ -330,7 +330,7 @@ namespace NamespaceQFT
     {
         static void Main(string[] args)
         {
-            using var qsim = new QuantumSimulator()
+            using (var qsim = new QuantumSimulator())
             {
                 Perform3QubitQFT.Run(qsim).Wait();
             }

--- a/articles/tutorial-qdk-qubit-level-program.md
+++ b/articles/tutorial-qdk-qubit-level-program.md
@@ -615,7 +615,7 @@ namespace NamespaceQFT
     {
         static void Main(string[] args)
         {
-            use var qsim = new QuantumSimulator()
+            using var qsim = new QuantumSimulator()
             {
                 var measurementResult = Perform3QubitQFT.Run(qsim).Result;
                 System.Console.WriteLine(

--- a/articles/user-guide/machines/full-state-simulator.md
+++ b/articles/user-guide/machines/full-state-simulator.md
@@ -25,7 +25,7 @@ Create an instance of the `QuantumSimulator` class and then pass it to the `Run`
 of a quantum operation, along with any additional parameters.
 
 ```csharp
-    use var sim = new QuantumSimulator()
+    using var sim = new QuantumSimulator()
     {
         var res = myOperation.Run(sim).Result;
         ///...
@@ -64,7 +64,7 @@ Use the IQ# magic command [%simulate](xref:microsoft.quantum.iqsharp.magic-ref.s
 By default, the full state simulator uses a random number generator to simulate quantum randomness. For testing purposes, it is sometimes useful to have deterministic results. In a C# program, you can accomplish this by providing a seed for the random number generator in the `QuantumSimulator` constructor via the `randomNumberGeneratorSeed` parameter.
 
 ```csharp
-    use var sim = new QuantumSimulator(randomNumberGeneratorSeed: 42)
+    using var sim = new QuantumSimulator(randomNumberGeneratorSeed: 42)
     {
         var res = myOperationTest.Run(sim).Result;
         ///...

--- a/articles/user-guide/machines/full-state-simulator.md
+++ b/articles/user-guide/machines/full-state-simulator.md
@@ -25,7 +25,7 @@ Create an instance of the `QuantumSimulator` class and then pass it to the `Run`
 of a quantum operation, along with any additional parameters.
 
 ```csharp
-    using var sim = new QuantumSimulator()
+    using (var sim = new QuantumSimulator())
     {
         var res = myOperation.Run(sim).Result;
         ///...
@@ -64,7 +64,7 @@ Use the IQ# magic command [%simulate](xref:microsoft.quantum.iqsharp.magic-ref.s
 By default, the full state simulator uses a random number generator to simulate quantum randomness. For testing purposes, it is sometimes useful to have deterministic results. In a C# program, you can accomplish this by providing a seed for the random number generator in the `QuantumSimulator` constructor via the `randomNumberGeneratorSeed` parameter.
 
 ```csharp
-    using var sim = new QuantumSimulator(randomNumberGeneratorSeed: 42)
+    using (var sim = new QuantumSimulator(randomNumberGeneratorSeed: 42))
     {
         var res = myOperationTest.Run(sim).Result;
         ///...


### PR DESCRIPTION
"Use" is Q#-only syntax, C# only supports "using"