### PR TITLE
Transforming version info on the Workspace article into NOTE 

### DIFF
--- a/articles/optimization-workspace.md
+++ b/articles/optimization-workspace.md
@@ -77,7 +77,10 @@ for job in jobs:
 > f0c8de58-68f1-11ea-a565-2a16a847b8a3 Executing
 ```
 
-The Workspace.list_jobs method also allows the user to filter on the creation date, status and name properties of a job when listing. Filters can be combined. To use the filter feature, you must have **version 0.18.2107** or newer of the SDK. 
+The Workspace.list_jobs method also allows the user to filter on the creation date, status and name properties of a job when listing. Filters can be combined. 
+
+> [!NOTE]
+> To use the filter feature, you must have **version 0.18.2107** or newer of the [Python SDK for Azure Quantum](https://docs.microsoft.com/azure/quantum/optimization-install-sdk). 
 
 ### Filtering by creation time on list_jobs
 


### PR DESCRIPTION
This means it can easily be taken out once version 18.2107 isn't one of the latest anymore