### PR TITLE
Update service-principal authentication instructions

### DIFF
--- a/articles/optimization-authenticate-service-principal.md
+++ b/articles/optimization-authenticate-service-principal.md
@@ -49,36 +49,38 @@ To create a service principal, assign access, and generate a credential:
     1. Search for and select the service principal.
     1. Assign either the **Contributor** or **Owner** role.
 
+> [!NOTE]
+> In order to create a role assignment on the resource group or workspace, you need to be an _owner_ or _user access administrator_ at the scope of the role assignment. If you do not have permissions to create the Service Principal in your subscription, you will need to request permission from the _owner_ or _administrator_ of the Azure subscription.
+>
+> If you have permissions only at Resource Group or Workspace level, you can try to create the service principal without subscription level assignment using:
+>
+> ```az ad sp create-for-rbac --skip-assignment true```
+>
+> Then, based on the output for the Service Principal name, you can go directly to the Resource Group or Azure Quantum Workspace in the portal to create a role assignment for that Service Principal, and assign the _contributor_ role. 
+
 ## Authenticate as the service principal
 
-**Step 1**: Install the `azure-common` python package:
+**Option 1: Using environment variables**:
+The default credential used in the `Workspace` object creation is the [DefaultAzureCredential](https://azuresdkdocs.blob.core.windows.net/$web/python/azure-identity/1.6.0/azure.identity.html#azure.identity.DefaultAzureCredential), which will attempt several types of authentication.
+The first one is the [EnvironmentCredential](https://azuresdkdocs.blob.core.windows.net/$web/python/azure-identity/1.6.0/azure.identity.html#azure.identity.EnvironmentCredential), and with that you pass pass the Service Principal credentials via the following environment variables:
+- **AZURE_TENANT_ID**: ID of the service principal’s tenant. Also called its ‘directory’ ID.
+- **AZURE_CLIENT_ID**: the service principal’s client ID
+- **AZURE_CLIENT_SECRET**: one of the service principal’s client secrets
 
-```bash
-pip3 install azure-common
-```
-
-**Step 2**: Before you call `workspace.login()`, instantiate your service
-principal and provide it to the workspace:
+**Option 2: Using the ClientSecretCredential**: Pass a [ClientSecretCredential](/python/api/azure-identity/azure.identity.clientsecretcredential) during the instantiation of the `Workspace` object or set the its `credentials` property.
 
 ```python
-from azure.common.credentials import ServicePrincipalCredentials
-workspace.credentials = ServicePrincipalCredentials(
-    tenant    = "", # From service principal creation, your Directory (tenant) ID
-    client_id = "", # From service principal creation, your Application (client) ID
-    secret    = "", # From service principal creation, your secret
-    resource  = "https://quantum.microsoft.com" # Do not change! This is the resource you want to authenticate against - the Azure Quantum service
-)
+from azure.identity import ClientSecretCredential
+
+tenant_id = os.environ["AZURE_TENANT_ID"]
+client_id = os.environ["AZURE_CLIENT_ID"]
+client_secret = os.environ["AZURE_CLIENT_SECRET"]
+credential = ClientSecretCredential(tenant_id=tenant_id, client_id=client_id, client_secret=client_secret)
+
+workspace.credentials = credential
 ```
 
 > [!NOTE]
 > The `workspace.login()` method has been deprecated and is no longer necessary. The first time there is a call to the service, an authentication will be attempted using the credentials passed in the `Workspace` constructor or its `credentials` property. If no credentials were passed, several authentication methods will be attempted by the [DefaultAzureCredential](https://azuresdkdocs.blob.core.windows.net/$web/python/azure-identity/1.6.0/azure.identity.html#azure.identity.DefaultAzureCredential).
 
 
-> [!NOTE]
-> In order to create a role assignment on the resource group or workspace, you need to be an _owner_ or _user access administrator_ at the scope of the role assignment. If you do not have permissions to create the Service Principal in your subscription, you will need to request permission from the _owner_ or _administrator_ of the Azure subscription.
-
-If you have permissions only at Resource Group or Workspace level, you can try to create the service principal without subscription level assignment using:
-
-```az ad sp create-for-rbac --skip-assignment true```
-
-Then, based on the output for the Service Principal name, you can go directly to the Resource Group or Azure Quantum Workspace in the portal to create a role assignment for that Service Principal, and assign the _contributor_ role. 


### PR DESCRIPTION
This PR updates the instructions to use service-principal authentication based on the new `Azure.Identity` credentials.