### PR TITLE
Location of RangeSchedule in azure-quantum

### DIFF
--- a/articles/optimization-population-annealing.md
+++ b/articles/optimization-population-annealing.md
@@ -115,7 +115,8 @@ Population Annealing supports the following parameters:
 To create a parameterized Population Annealing solver for the CPU using the SDK:
 
 ```python
-from azure.quantum.optimization import PopulationAnnealing, RangeSchedule
+from azure.quantum.optimization import PopulationAnnealing
+from azure.quantum.target.solvers import RangeSchedule
 # Requires a workspace already created.
 solver = PopulationAnnealing(workspace, sweeps=200, beta=RangeSchedule("linear", 0, 5), population=128, seed=42)
 ```

--- a/articles/optimization-substochastic-monte-carlo.md
+++ b/articles/optimization-substochastic-monte-carlo.md
@@ -119,7 +119,8 @@ Substochastic Monte Carlo supports the following parameters:
 To create a parameterized Substochastic Monte Carlo solver for the CPU using the SDK:
 
 ```python
-from azure.quantum.optimization import SubstochasticMonteCarlo, RangeSchedule
+from azure.quantum.optimization import SubstochasticMonteCarlo
+from azure.quantum.target.solvers import RangeSchedule
 # Requires a workspace already created.
 solver = SubstochasticMonteCarlo(workspace, step_limit=10000, target_population=64, beta=RangeSchedule("linear", 0, 5), seed=42)
 ```


### PR DESCRIPTION
RangeSchedule is now under azure.quantum.target.solvers rather than azure.quantum.optimization