### PR TITLE
Change name of conda channel.

### DIFF
--- a/articles/install-jupyter-qdk.md
+++ b/articles/install-jupyter-qdk.md
@@ -41,7 +41,7 @@ IQ# (pronounced i-q-sharp) is an extension primarily used by Jupyter and Python 
 1. From a new terminal, create and activate a new conda environment named `qsharp-env` with the required packages (including Jupyter Notebook and IQ#) by running the following commands:
 
     ```shell
-    conda create -n qsharp-env -c quantum-engineering qsharp notebook
+    conda create -n qsharp-env -c microsoft qsharp notebook
 
     conda activate qsharp-env
     ```

--- a/articles/install-python-qdk.md
+++ b/articles/install-python-qdk.md
@@ -39,7 +39,7 @@ The `qsharp` Python package, which includes the IQ# kernel, contains the necessa
 1. From a new terminal, create and activate a new conda environment named `qsharp-env` with the required packages (including Jupyter Notebook and IQ#) by running the following commands:
 
     ```shell
-    conda create -n qsharp-env -c quantum-engineering qsharp notebook
+    conda create -n qsharp-env -c microsoft qsharp notebook
 
     conda activate qsharp-env
     ```

--- a/articles/install-update-qdk.md
+++ b/articles/install-update-qdk.md
@@ -166,7 +166,7 @@ The update procedure depends on whether you originally installed using conda or 
 1. Activate the conda environment where you installed the `qsharp` package, and then run this command to update it:
 
     ```
-    conda update -c quantum-engineering qsharp
+    conda update -c microsoft qsharp
     ```
 
 1. Run the following command from the location of your `.qs` files:
@@ -239,7 +239,7 @@ The update procedure depends on whether you originally installed using conda or 
 1. Activate the conda environment where you installed the `qsharp` package, and then run this command to update it:
 
     ```
-    conda update -c quantum-engineering qsharp
+    conda update -c microsoft qsharp
     ```
 
 1. Run the following command from a cell in each of your existing Q# Jupyter Notebooks:


### PR DESCRIPTION
This PR updates documentation for Q# notebook and Q# + Python usage to point to the new conda channel, https://anaconda.org/microsoft, that will be used from Quantum Development Kit v0.19 and forward. 