### PR TITLE
Equation example typo

### DIFF
--- a/articles/concepts-dirac-notation.md
+++ b/articles/concepts-dirac-notation.md
@@ -111,7 +111,7 @@ As a side note, in this example we did not use $\ket{+}^{\otimes n}=\ket{+}$ in 
 
 Another nice feature of Dirac notation is the fact that it is linear. For example, for two complex numbers $\alpha$ and $\beta$, we can write
 
-$$ \ket{\psi} \otimes ( \alpha\ket{\phi} + \beta\ket{\chi})= \alpha\gamma \ket{\psi}\ket{\phi} + \beta\ket{\psi}\ket{\chi}.$$
+$$ \ket{\psi} \otimes ( \alpha\ket{\phi} + \beta\ket{\chi})= \alpha\ket{\psi}\ket{\phi} + \beta\ket{\psi}\ket{\chi}.$$
 
 That is to say, you can distribute the tensor product notation in Dirac notation so that taking tensor products between state vectors ends up looking just like ordinary multiplication.
 


### PR DESCRIPTION
In the first equation example under the "Express linearity with Dirac notation" section, there's an extra gamma γ on the right-hand side that never appears on the left-hand side, and so should be removed.
![image](https://user-images.githubusercontent.com/9160756/152467462-1eab04db-da83-4321-8ba3-65c0376a98c3.png)