### PR TITLE
Address Krysta's feedback on "Quickstart: Create a quantum-based random number generator in Azure Quantum"

### DIFF
--- a/articles/includes/quickstart-qc-include-ionq.md
+++ b/articles/includes/quickstart-qc-include-ionq.md
@@ -97,8 +97,12 @@ Next, we'll prepare your environment to run the program against the workspace yo
 
    ```
 
-> [!NOTE] 
-> The MyLocation parameter in the example above is the **Region** specified on the **Create Quantum Workspace** page when following the steps in [Create an Azure Quantum workspace](xref:microsoft.quantum.how-to.workspace).  Region and Location are synonymous.  The parameter value may be expressed in mixed case surrounded by quotes, e.g. `-l "West US 2"`, or in lower case with no spaces or quotes, e.g. `-l westus2`.
+    > [!NOTE]
+    > The MyLocation parameter in the example above is the **Region** 
+    > specified on the **Create Quantum Workspace** page when following 
+    > the steps in [Create an Azure Quantum workspace](xref:microsoft.quantum.how-to.workspace). Region > and Location are synonymous.  The parameter value may be expressed 
+    > in mixed case surrounded by quotes, e.g. `-l "West US 2"`, or in 
+    > lower case with no spaces or quotes, e.g. `-l westus2`.
 
 1. In your workspace, there are different targets available from the
    providers that you added when you created the workspace. You can display a list of all

--- a/articles/includes/quickstart-qc-include-ionq.md
+++ b/articles/includes/quickstart-qc-include-ionq.md
@@ -68,6 +68,8 @@ To complete this tutorial, you need
 
 Next, we'll prepare your environment to run the program against the workspace you created.
 
+1. From the Visual Studio Code menu, select **Terminal** -> **New Terminal**.
+
 1. Log in to Azure using your credentials. You'll get a list of subscriptions associated with your account.
 
    ```azurecli
@@ -77,7 +79,7 @@ Next, we'll prepare your environment to run the program against the workspace yo
 1. Specify the subscription you want to use from those associated with your Azure account. You can also find your subscription ID in the overview of your workspace in the Azure portal.
 
    ```azurecli
-   az account set -s <Your subscription ID>
+   az account set -s MySubscriptionID
    ```
    
 1. Use `quantum workspace set` to select the workspace you created above
@@ -94,6 +96,9 @@ Next, we'll prepare your environment to run the program against the workspace yo
     MyLocation  MyWorkspace  Succeeded            MyResourceGroup  /subscriptions/...  Yes
 
    ```
+
+> [!NOTE] 
+> The MyLocation parameter in the example above is the **Region** specified on the **Create Quantum Workspace** page when following the steps in [Create an Azure Quantum workspace](xref:microsoft.quantum.how-to.workspace).  Region and Location are synonymous.  The parameter value may be expressed in mixed case surrounded by quotes, e.g. `-l "West US 2"`, or in lower case with no spaces or quotes, e.g. `-l westus2`.
 
 1. In your workspace, there are different targets available from the
    providers that you added when you created the workspace. You can display a list of all

--- a/articles/includes/quickstart-qc-include-ionq.md
+++ b/articles/includes/quickstart-qc-include-ionq.md
@@ -68,7 +68,7 @@ To complete this tutorial, you need
 
 Next, we'll prepare your environment to run the program against the workspace you created.
 
-1. From the Visual Studio Code menu, select **Terminal** -> **New Terminal**.
+1. From the Visual Studio Code menu, select **Terminal** > **New Terminal**.
 
 1. Log in to Azure using your credentials. You'll get a list of subscriptions associated with your account.
 
@@ -102,8 +102,8 @@ Next, we'll prepare your environment to run the program against the workspace yo
     > specified on the **Create Quantum Workspace** page when following 
     > the steps in [Create an Azure Quantum workspace](xref:microsoft.quantum.how-to.workspace).
     > Region and Location are synonymous.  The parameter value may be 
-    > expressed in mixed case surrounded by quotes, e.g. `-l "West US 2"`,
-    > or in lower case with no spaces or quotes, e.g. `-l westus2`.
+    > expressed in mixed case surrounded by quotes, for example, `-l "West US 2"`,
+    > or in lower case with no spaces or quotes, such as `-l westus2`.
 
 1. In your workspace, there are different targets available from the
    providers that you added when you created the workspace. You can display a list of all

--- a/articles/includes/quickstart-qc-include-ionq.md
+++ b/articles/includes/quickstart-qc-include-ionq.md
@@ -100,9 +100,10 @@ Next, we'll prepare your environment to run the program against the workspace yo
     > [!NOTE]
     > The MyLocation parameter in the example above is the **Region** 
     > specified on the **Create Quantum Workspace** page when following 
-    > the steps in [Create an Azure Quantum workspace](xref:microsoft.quantum.how-to.workspace). Region > and Location are synonymous.  The parameter value may be expressed 
-    > in mixed case surrounded by quotes, e.g. `-l "West US 2"`, or in 
-    > lower case with no spaces or quotes, e.g. `-l westus2`.
+    > the steps in [Create an Azure Quantum workspace](xref:microsoft.quantum.how-to.workspace).
+    > Region and Location are synonymous.  The parameter value may be 
+    > expressed in mixed case surrounded by quotes, e.g. `-l "West US 2"`,
+    > or in lower case with no spaces or quotes, e.g. `-l westus2`.
 
 1. In your workspace, there are different targets available from the
    providers that you added when you created the workspace. You can display a list of all

--- a/articles/includes/quickstart-qc-include-quantinuum.md
+++ b/articles/includes/quickstart-qc-include-quantinuum.md
@@ -99,9 +99,10 @@ Next, we'll prepare your environment to run the program against the workspace yo
     > [!NOTE]
     > The MyLocation parameter in the example above is the **Region** 
     > specified on the **Create Quantum Workspace** page when following 
-    > the steps in [Create an Azure Quantum workspace](xref:microsoft.quantum.how-to.workspace). Region > and Location are synonymous.  The parameter value may be expressed 
-    > in mixed case surrounded by quotes, e.g. `-l "West US 2"`, or in 
-    > lower case with no spaces or quotes, e.g. `-l westus2`.
+    > the steps in [Create an Azure Quantum workspace](xref:microsoft.quantum.how-to.workspace).
+    > Region and Location are synonymous.  The parameter value may be 
+    > expressed in mixed case surrounded by quotes, e.g. `-l "West US 2"`,
+    > or in lower case with no spaces or quotes, e.g. `-l westus2`.
 
 1. In your workspace, there are different targets available from the
    providers that you added when you created the workspace. You can display a list of all

--- a/articles/includes/quickstart-qc-include-quantinuum.md
+++ b/articles/includes/quickstart-qc-include-quantinuum.md
@@ -67,7 +67,7 @@ To complete this tutorial, you need
 
 Next, we'll prepare your environment to run the program against the workspace you created.
 
-1. From the Visual Studio Code menu, select **Terminal** -> **New Terminal**.
+1. From the Visual Studio Code menu, select **Terminal** > **New Terminal**.
 
 1. Log in to Azure using your credentials. You'll get a list of subscriptions associated with your account.
 
@@ -101,8 +101,8 @@ Next, we'll prepare your environment to run the program against the workspace yo
     > specified on the **Create Quantum Workspace** page when following 
     > the steps in [Create an Azure Quantum workspace](xref:microsoft.quantum.how-to.workspace).
     > Region and Location are synonymous.  The parameter value may be 
-    > expressed in mixed case surrounded by quotes, e.g. `-l "West US 2"`,
-    > or in lower case with no spaces or quotes, e.g. `-l westus2`.
+    > expressed in mixed case surrounded by quotes, for example, `-l "West US 2"`,
+    > or in lower case with no spaces or quotes, such as `-l westus2`.
 
 1. In your workspace, there are different targets available from the
    providers that you added when you created the workspace. You can display a list of all

--- a/articles/includes/quickstart-qc-include-quantinuum.md
+++ b/articles/includes/quickstart-qc-include-quantinuum.md
@@ -96,8 +96,12 @@ Next, we'll prepare your environment to run the program against the workspace yo
 
    ```
 
-> [!NOTE] 
-> The MyLocation parameter in the example above is the **Region** specified on the **Create Quantum Workspace** page when following the steps in [Create an Azure Quantum workspace](xref:microsoft.quantum.how-to.workspace).  Region and Location are synonymous.  The parameter value may be expressed in mixed case surrounded by quotes, e.g. `-l "West US 2"`, or in lower case with no spaces or quotes, e.g. `-l westus2`.
+    > [!NOTE]
+    > The MyLocation parameter in the example above is the **Region** 
+    > specified on the **Create Quantum Workspace** page when following 
+    > the steps in [Create an Azure Quantum workspace](xref:microsoft.quantum.how-to.workspace). Region > and Location are synonymous.  The parameter value may be expressed 
+    > in mixed case surrounded by quotes, e.g. `-l "West US 2"`, or in 
+    > lower case with no spaces or quotes, e.g. `-l westus2`.
 
 1. In your workspace, there are different targets available from the
    providers that you added when you created the workspace. You can display a list of all

--- a/articles/includes/quickstart-qc-include-quantinuum.md
+++ b/articles/includes/quickstart-qc-include-quantinuum.md
@@ -67,6 +67,8 @@ To complete this tutorial, you need
 
 Next, we'll prepare your environment to run the program against the workspace you created.
 
+1. From the Visual Studio Code menu, select **Terminal** -> **New Terminal**.
+
 1. Log in to Azure using your credentials. You'll get a list of subscriptions associated with your account.
 
    ```azurecli
@@ -76,7 +78,7 @@ Next, we'll prepare your environment to run the program against the workspace yo
 1. Specify the subscription you want to use from those associated with your Azure account. You can also find your subscription ID in the overview of your workspace in the Azure portal.
 
    ```azurecli
-   az account set -s <Your subscription ID>
+   az account set -s MySubscriptionID
    ```
 
 1. Use `quantum workspace set` to select the workspace you created above
@@ -93,6 +95,9 @@ Next, we'll prepare your environment to run the program against the workspace yo
     MyLocation  MyWorkspace  Succeeded            MyResourceGroup  /subscriptions/...  Yes
 
    ```
+
+> [!NOTE] 
+> The MyLocation parameter in the example above is the **Region** specified on the **Create Quantum Workspace** page when following the steps in [Create an Azure Quantum workspace](xref:microsoft.quantum.how-to.workspace).  Region and Location are synonymous.  The parameter value may be expressed in mixed case surrounded by quotes, e.g. `-l "West US 2"`, or in lower case with no spaces or quotes, e.g. `-l westus2`.
 
 1. In your workspace, there are different targets available from the
    providers that you added when you created the workspace. You can display a list of all


### PR DESCRIPTION
Feedback from Krysta:

I get it set up and then to “[Prepare the Azure CLI](https://docs.microsoft.com/en-us/azure/quantum/quickstart-microsoft-qc?pivots=platform-ionq#prepare-the-azure-cli)”
- Here I expected to be in the portal again given the earlier mode of interaction.
- It’s not clear where this code is to be written?  I think it should be in cmd but that’s not explicitly stated anywhere.
- I open cmd and start writing the code on the page.
- I get to step 3 --- not clear how to easily find “location”
- Like the code line above it, should the user-based text here be in red?: az quantum workspace set -g MyResourceGroup -w MyWorkspace -l MyLocation -o table
- Could be worth helping user understand the tab inside the Azure resource in case user is new to azure…for example now to go back to portal, create workspace, but if you already have one you can reuse that one and find it by cicking on the subscription and then “resources” area (took me a minute to find this)
- To put in location, they don’t want the same text the location is listed in…for example I typed West US and it said US is not allowed.  What is form of location text that can be used?  Does it need quotes, etc?  Help user do this step to insert their code into “MyLocation” text portion above.  Took me a few tries to figure out this requires double quotes around the location string, or accepts it as all one word lower case also.  Note this is also not documented well in Azure CLI either, which is where the failure of the command points you to.