### PR TITLE
Update how-to-submit-quantum-include-azurecli.md

### DIFF
--- a/articles/includes/how-to-submit-quantum-include-azurecli.md
+++ b/articles/includes/how-to-submit-quantum-include-azurecli.md
@@ -104,7 +104,7 @@ You will also find a full reference for all commands and features available thro
 1. You can use the job ID to track its status:
 
    ```azurecli
-   az quantum job show -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy -o table
+   az quantum job show -id yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy -o table
    ```
 
    ```output
@@ -121,7 +121,7 @@ You will also find a full reference for all commands and features available thro
    job output`:
 
    ```azurecli
-    az quantum job output -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy -o table
+    az quantum job output -id yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy -o table
    ```
 
    ```output
@@ -196,7 +196,7 @@ Once the job completes (that is, when it's in a **Successful** state), use the c
 job output` to view the results:
 
 ```azurecli
-az quantum job output -j yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy -o table
+az quantum job output -id yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy -o table
 ```
 
 ```output


### PR DESCRIPTION
Not sure when this was changed, but referencing a quantum job (with either az quantum job show or az quantum job output) requires passing the job id with the '-id' parameter, not the '-j' parameter. Doing so with '-j' parameter will throw the error 'the following arguments are required: --job-id/-id'.