### PR TITLE
update honeywell references to quantinuum

### DIFF
--- a/articles/get-started-jupyter-notebook.md
+++ b/articles/get-started-jupyter-notebook.md
@@ -85,15 +85,15 @@ Some things to note:
 - **5th cell**: Sets the target and submits the job. 
 - **6th and 7th cells**: Plots and displays the result.
 
-Looking at the histogram, you may notice that the program returned 0 every time, which is not very random. This is because the notebook was prepopulated to use the **Honeywell API Validator**, *honeywell.hqs-lt-s1-apival*. Using the API Validator ensures that your code will run successfully on Quantinuum hardware, but also returns 0 for every quantum measurement. 
+Looking at the histogram, you may notice that the program returned 0 every time, which is not very random. This is because the notebook was prepopulated to use the **Quantinuum Syntax Checker**, *quantinuum.hqs-lt-s1-apival*. Using the API Validator ensures that your code will run successfully on Quantinuum hardware, but also returns 0 for every quantum measurement. 
 
-To create a true random number generator, modify the code in the 5th cell to use the **System Model H1 Emulator** target, *honeywell.hqs-lt-s1-sim*
+To create a true random number generator, modify the code in the 5th cell to use the **System Model H1 Emulator** target, *quantinuum.hqs-lt-s1-sim*
 
 > [!NOTE]
 > Running the program against the H1 Emulator or the System Model H1 computer will use H-System Quantum Credits (HQC) from your account. A single run of this example program costs approximately 5.3 HQC.
 
 ```python
-qsharp.azure.target("honeywell.hqs-lt-s1-sim")
+qsharp.azure.target("quantinuum.hqs-lt-s1-sim")
 ```
 
 Re-run that cell and the following cells. Now, the results should be roughly split between 0 and 1. 

--- a/articles/get-started-jupyter-notebook.md
+++ b/articles/get-started-jupyter-notebook.md
@@ -85,7 +85,7 @@ Some things to note:
 - **5th cell**: Sets the target and submits the job. 
 - **6th and 7th cells**: Plots and displays the result.
 
-Looking at the histogram, you may notice that the program returned 0 every time, which is not very random. This is because the notebook was prepopulated to use the **Quantinuum Syntax Checker**, *quantinuum.hqs-lt-s1-apival*. Using the API Validator ensures that your code will run successfully on Quantinuum hardware, but also returns 0 for every quantum measurement. 
+Looking at the histogram, you may notice that the program returned 0 every time, which is not very random. This is because the notebook was prepopulated to use the **Quantinuum Syntax Checker**, *quantinuum.hqs-lt-s1-apival*. Using the Syntax Checker ensures that your code will run successfully on Quantinuum hardware, but also returns 0 for every quantum measurement. 
 
 To create a true random number generator, modify the code in the 5th cell to use the **System Model H1 Emulator** target, *quantinuum.hqs-lt-s1-sim*
 

--- a/articles/includes/quickstart-cirq-include-honeywell-portal.md
+++ b/articles/includes/quickstart-cirq-include-honeywell-portal.md
@@ -109,13 +109,13 @@ Estimated cost: 5.42
 
 This prints the estimated cost in H-System Quantum Credits (HQCs).
 
-For the most current pricing details, see [System Model H1, Powered by Honeywell](xref:microsoft.quantum.providers.honeywell#honeywell-system-model-h1), or view pricing options in the **Providers** blade of your workspace. To see your current credit status and usage, select **Credits and quotas**.
+For the most current pricing details, see [System Model H1, Powered by Honeywell](xref:microsoft.quantum.providers.quantinuum#quantinuum-system-model-h1), or view pricing options in the **Providers** blade of your workspace. To see your current credit status and usage, select **Credits and quotas**.
 
-## Run on a Quantinuum QPU 
+## Run on a Quantinuum QPU
 
 After running successfully on the API validator and estimating the QPU cost, it's time to run your circuit on the hardware. 
 
-> [!NOTE] 
+> [!NOTE]
 > The time required to run a circuit on the QPU depends on current queue times. You can view the average queue time for a target by selecting the **Providers** blade of your workspace.
 
 Use the same `run` method and operations that you used previously with the API Validator to submit your job and display the results:

--- a/articles/includes/quickstart-provider-include-honeywell-portal.md
+++ b/articles/includes/quickstart-provider-include-honeywell-portal.md
@@ -52,7 +52,7 @@ This workspace's targets:
 
 ## Select a target and run your program
 
-To check your circuit before running it on actual quantum hardware, you can use the [Quantinuum API validator](xref:microsoft.quantum.providers.honeywell#api-validator), `quantinuum.hqs-lt-s1-apival`, which returns a `Job` object. For more information, see [Azure Quantum Job](xref:microsoft.quantum.optimization.job-reference).
+To check your circuit before running it on actual quantum hardware, you can use the [Quantinuum API validator](xref:microsoft.quantum.providers.quantinuum#api-validator), `quantinuum.hqs-lt-s1-apival`, which returns a `Job` object. For more information, see [Azure Quantum Job](xref:microsoft.quantum.optimization.job-reference).
 
 Run the following code to set the target to the API Validator and submit your circuit with 500 shots:
 
@@ -91,7 +91,7 @@ pl.ylabel("Counts")
 pl.xlabel("Bitstring")
 ```
 
-![Quantinuum job output](../media/honeywell-results.png)
+![Quantinuum job output](../media/quantinuum-results.png)
 
 Looking at the histogram, you may notice that all the measurements are 0.  This is because that, while the Quantinuum API validator target ensures that your code will run successfully on Quantinuum hardware, it also returns 0 for every quantum measurement. For an accurate measurement of your circuit, you need to run it on quantum hardware.
 
@@ -139,6 +139,6 @@ pl.ylabel("Counts")
 pl.xlabel("Bitstring")
 ```
 
-![Quantinuum job output qpu](../media/honeywell-results-qpu.png)
+![Quantinuum job output qpu](../media/quantinuum-results-qpu.png)
 
 Note that the measurements now are roughly split between 0 and 1.

--- a/articles/provider-quantinuum.md
+++ b/articles/provider-quantinuum.md
@@ -24,8 +24,8 @@ Quantinuum provides access to trapped-ion systems with high-fidelity, fully conn
 
 The following targets are available from this provider:
 
-- [Syntax Checker](#syntax-checker)
-- [System Model H1 Emulator](#system-model-h1-emulator)
+- [Syntax Checker](#syntax-checkers)
+- [System Model H1 Emulator](#system-model-h1-emulators)
 - [System Model H1](#system-model-h1)
 
 ## Target Availability
@@ -43,7 +43,7 @@ Current status information may be retrieved from the *Providers* tab of a worksp
 We recommend that users first validate their code using a Syntax Checker. This is a tool to verify proper syntax, compilation completion, and machine compatibility. Syntax Checkers use the same compiler as the quantum computer they target. For example, the H1-2 syntax checker uses the same compiler as H1-2. The full compilation stack is executed with the exception of the actual quantum operations. If the code compiles, the syntax checker will return a `success` status and a result of all 0s. If the code does not compile, the syntax checker will return a failed status and give the error returned to help users debug their circuit syntax. Syntax Checkers allow developers to validate their code at any time, even when machines are offline.
 
 - Job type: `Simulation`
-- Data Format: `honeywell.openqasm.v1`
+- Data Format: `quantinuum.openqasm.v1`
 - Target ID: `quantinuum.hqs-lt-s1-apival` or `quantinuum.hqs-lt-s2-apival`
 - Target Execution Profile: [Basic Measurement Feedback](xref:microsoft.quantum.target-profiles)
 
@@ -54,7 +54,7 @@ Billing information:  No charge for usage.
 After validating the syntax of their code with a Syntax Checker, users can take advantage of Quantinuum's H1 Emulators, emulation tools which contains a detailed physical model and realistic noise model of the actual System Model H1 hardware. The noise model is derived from a detailed characterization of the H1-1 hardware and is also representative of H1-2 hardware performance. The System Model H1 Emulator uses an identical API for job submission as the System Model H1 hardware, enabling seamless transition from emulation to hardware. To help maximize productivity and shorten development time, the H1 Emulator is available even while the hardware is offline.
 
 - Job type: `Simulation`
-- Data Format: `honeywell.openqasm.v1`
+- Data Format: `quantinuum.openqasm.v1`
 - Target ID:  `quantinuum.hqs-lt-s1-sim` or `quantinuum.hqs-lt-s2-sim`
 - Target Execution Profile: [Basic Measurement Feedback](xref:microsoft.quantum.target-profiles)
 
@@ -69,7 +69,7 @@ Users may submit jobs to a specific machine (H1-1 or H1-2), or submit them to th
 Both System Model H1 hardware H1-1 and H1-2 are continuously upgraded throughout their product lifecycle. Users are given access to the most up-to-date, advanced, and capable hardware available.
 
 - Job type: `Quantum Program`
-- Data Format: `honeywell.openqasm.v1`
+- Data Format: `quantinuum.openqasm.v1`
 - Target ID:
   - H1-1: `quantinuum.hqs-lt-s1` 
   - H1-2: `quantinuum.hqs-lt-s2`

--- a/articles/quickstart-microsoft-cirq-portal.md
+++ b/articles/quickstart-microsoft-cirq-portal.md
@@ -88,7 +88,7 @@ location of your Azure Quantum workspace:
 
 ::: zone pivot="platform-quantinuum"
 
-[!INCLUDE [quantinuum-procedure](includes/quickstart-cirq-include-honeywell-portal.md)]
+[!INCLUDE [quantinuum-procedure](includes/quickstart-cirq-include-quantinuum-portal.md)]
 
 ::: zone-end
 

--- a/articles/quickstart-microsoft-provider-format-portal.md
+++ b/articles/quickstart-microsoft-provider-format-portal.md
@@ -88,7 +88,7 @@ location of your Azure Quantum workspace:
 
 ::: zone pivot="platform-quantinuum"
 
-[!INCLUDE [quantinuum-procedure](includes/quickstart-provider-include-honeywell-portal.md)]
+[!INCLUDE [quantinuum-procedure](includes/quickstart-provider-include-quantinuum-portal.md)]
 
 ::: zone-end
 

--- a/articles/quickstart-microsoft-qiskit-portal.md
+++ b/articles/quickstart-microsoft-qiskit-portal.md
@@ -141,7 +141,7 @@ This workspace's targets:
 
 ::: zone pivot="platform-quantinuum"
 
-[!INCLUDE [quantinuum-procedure](includes/quickstart-qiskit-include-honeywell-portal.md)]
+[!INCLUDE [quantinuum-procedure](includes/quickstart-qiskit-include-quantinuum-portal.md)]
 
 ::: zone-end
 


### PR DESCRIPTION
Found a few more locations where honeywell is used in links or references. Updated these to Quantinuum or `quantinuum` as makes sense.