### PR TITLE
fix HQC acronym reference

### DIFF
--- a/articles/includes/pricing-qc.md
+++ b/articles/includes/pricing-qc.md
@@ -80,12 +80,12 @@ For more information about Azure infrastructure costs, see [Azure Blob Storage p
 
 ## Quantinuum
 
-[Quantinuum](https://www.quantinuum.com/) uses a credit system that charges each job depending on the number of operations in the job, and the number of shots you run. The usage units are *H-System Quantum Credits (HQCs)* for jobs submitted to System Model H1 quantum computers, Powered by Honeywell, and *Emulator Quantum Credits (eHQC)* for jobs submitted to System Model H1 Emulators.
+[Quantinuum](https://www.quantinuum.com/) uses a credit system that charges each job depending on the number of operations in the job, and the number of shots you run. The usage units are *H-System Quantum Credits (HQCs)* for jobs submitted to System Model H1 quantum computers, Powered by Honeywell, and emulator HQCs (eHQCs) for jobs submitted to System Model H1 emulators.
 
 > [!NOTE]
 > Do not confuse the Quantinuum HQCs with the Azure Quantum credits. Quantinuum HQCs are a usage unit defined by the provider to track the usage and quotas of their targets.
 
-HQC and eHQC are used to calculate the cost of running a job, and they are calculated based on the following formula:
+HQCs and eHQCs are used to calculate the cost of running a job, and they are calculated based on the following formula:
 
 $$
 HQC = 5 + C(N_{1q} + 10 N_{2q} + 5 N_m)/5000

--- a/articles/provider-quantinuum.md
+++ b/articles/provider-quantinuum.md
@@ -103,9 +103,9 @@ To see Quantinuum's billing plans, visit [Azure Quantum pricing](xref:microsoft.
 
 ## Limits & Quotas
 
-Quantinuum's quotas are tracked based on the QPU usage credit unit, which is *H1 Quantum Credit (HQC)* for jobs submitted to System Model H1 quantum computer, and *Quantinuum Emulator Quantum Credits (eHQC)* for jobs submitted to System Model H1 emulator.
+Quantinuum's quotas are tracked based on the QPU usage credit unit, *H-System Quantum Credit (HQC)*, for jobs submitted to System Model H1 quantum computers, and emulator HQCs (eHQCs) for jobs submitted to System Model H1 emulators.
 
-HQC and eHQC are used to calculate the cost of running a job, and they are calculated based on the following formula (same for eHQC):
+HQCs and eHQCs are used to calculate the cost of running a job, and they are calculated based on the following formula:
 
 $$
 HQC = 5 + C(N_{1q} + 10 N_{2q} + 5 N_m)/5000


### PR DESCRIPTION
Fixed a reference to HQCs that was incorrect (should be H-System Quantum Credit)