### PR TITLE
Change 'targets' to 'providers' in page title

### DIFF
--- a/articles/qc-target-list.md
+++ b/articles/qc-target-list.md
@@ -7,7 +7,7 @@ ms.service: azure-quantum
 ms.subservice: core
 ms.topic: reference
 no-loc: [Quantum Intermediate Representation, target, targets]
-title: List of quantum computing targets on Azure Quantum
+title: List of quantum computing providers on Azure Quantum
 uid: microsoft.quantum.reference.qc-target-list
 ---
 


### PR DESCRIPTION
Change 'targets' to 'providers' in page title. 
My motivation for this pull request is just because the page headline is `Quantum computing providers on Azure Quantum` and it seems that `providers` can fit.

I noticed it because I added a bookmark on this page and needed to change it manually.