### PR TITLE
Update tutorial-qdk-quantum-random-number-generator.md

### DIFF
--- a/articles/includes/tutorial-entanglement-copilot-include.md
+++ b/articles/includes/tutorial-entanglement-copilot-include.md
@@ -20,7 +20,7 @@ For more information about the Copilot, see [Explore Azure Quantum](xref:microso
 
 The first step is to define a Q# operation that will initialize a qubit to a known state. This can be called to set a qubit to a classical state, meaning that, when measured, it either returns `Zero` 100% of the time or returns `One` 100% of the time. Measuring a qubit returns a Q# type `Result`, which can only have a value of `Zero` or `One`.
 
-Open the [Copilot for Azure Quantum](https://quantum.microsoft.com/experience/quantum-coding) and copy the following code into de code editor window. Don't click **Run** yet; you'll run the code later in the tutorial.
+Open the [Copilot for Azure Quantum](https://quantum.microsoft.com/experience/quantum-coding) and copy the following code into the code editor window. Don't click **Run** yet; you'll run the code later in the tutorial.
 
 ```qsharp
    namespace Bell {

--- a/articles/tutorial-qdk-quantum-random-number-generator.md
+++ b/articles/tutorial-qdk-quantum-random-number-generator.md
@@ -130,7 +130,7 @@ In the Bloch sphere, the north pole represents the classical value **0** and the
 
 You can use this representation to visualize what the code is doing:
 
-1. First, start with a qubit initialized in the state **0** and apply an `H` operation to create an equal superposition in which the probabilities for **0** and **1** are the ame.
+1. First, start with a qubit initialized in the state **0** and apply an `H` operation to create an equal superposition in which the probabilities for **0** and **1** are the same.
 
     <img src="~/media/qrng-H.png" width="450" alt="A diagram showing the preparation of a qubit in superposition by applying the hadamard gate.">
 


### PR DESCRIPTION
Correct the spelling from ame to same under the "Visualize the Q# code with the Bloch Sphere" section under the first step.

Simple change, if it is too simple please close.