### PR TITLE
Python Doc Update

### DIFF
--- a/articles/user-guide/how-to-work-with-qsharp-projects.md
+++ b/articles/user-guide/how-to-work-with-qsharp-projects.md
@@ -72,7 +72,7 @@ you would set the `project_root` before making calls to any Q# operations:
 ```python
 import qsharp
 
-qsharp.init(project_root = '/Teleportation_project')
+qsharp.init(project_root = './Teleportation_project')
 ```
 
 The path of the root folder is relative to the file that is setting it, meaning that your program doesn't necessarily have to be in the project. A valid path may also be `'./MyProjects/Teleportation_project'`
@@ -169,7 +169,7 @@ MyMathLib.Multiply(x,y);
 1. If you are accessing the project from a Python program or Jupyter Notebook, set the root folder path using `qsharp.init`, for example:
 
     ```python
-    qsharp.init(project_root = '/Teleportation_project')
+    qsharp.init(project_root = './Teleportation_project')
     ```
 1. If you are using only Q# files in VS Code, when you open a Q# file, the compiler searches for the *qsharp.json* manifest file, determine the project root folder, and then scan the subfolder for \*.qs files. 
 
@@ -279,7 +279,7 @@ import qsharp
 ```python
 # set the root folder for the project
 # make adjustments to the path depending on where your program is saved
-qsharp.init(project_root = '/Teleportation_project')
+qsharp.init(project_root = './Teleportation_project')
 
 ```
 


### PR DESCRIPTION
### Issue
As per this [doc](https://learn.microsoft.com/en-us/azure/quantum/user-guide/how-to-work-with-qsharp-projects?tabs=tabid-qsharp%2Ctabid-python-run#steps-for-creating-a-q-project), we need to use `qsharp.init(project_root = '/Teleportation_project')`. 

My Github repo by following [sample](https://learn.microsoft.com/en-us/azure/quantum/user-guide/how-to-work-with-qsharp-projects?tabs=tabid-qsharp%2Ctabid-python-run#steps-for-creating-a-q-project): https://github.com/Manvi-Agrawal/QSharp-Sample

#### My Platform Details
- Windows
- Qsharp Version: 1.3.1

PS: Issue verfied by @tcNickolas on Ubuntu

### Error Message
Error:
 raise QSharpError(
module.QSharpError: /Teleportation_project\qsharp.json not found. qsharp.json should exist at the project root and be a valid JSON file.

### Fix 
- Use relative import. When I edit the doc, I see the following advice, but it isnt on the public doc.
> The path of the root folder is relative to the file that is setting it, meaning that your program doesn't necessarily have to be in the project. A valid path may also be `'./MyProjects/Teleportation_project'`


### Additional Details(Screenshots of current doc)
![image](https://github.com/MicrosoftDocs/quantum-docs/assets/40084144/4c1cfa5d-0e09-4257-8297-6971768d0cff)
