### PR TITLE
Update testing-debugging.md

### DIFF
--- a/articles/user-guide/testing-debugging.md
+++ b/articles/user-guide/testing-debugging.md
@@ -63,7 +63,7 @@ The [`fail`](xref:microsoft.quantum.qsharp.returnsandtermination#fail-expression
 
 Consider this simple example that validates a parameter value:
 
-```qsharp
+```python
 %%qsharp
 
 function PositivityFact(value : Int) : Unit {
@@ -99,7 +99,7 @@ Here, the `fail` expression prevents the program from continuing to run with inv
 
 You can implement the same behavior as the previous example using the `Fact()` function from the `Microsoft.Quantum.Diagnostics` namespace. The `Fact()` function evaluates a given classical condition and throws an exception if it is false. 
 
-```qsharp
+```python
 %%qsharp
 
     function PositivityFact(value : Int) : Unit {
@@ -141,7 +141,7 @@ Qsc.Eval.UserFail
 import qsharp
 ```
 
-```qsharp
+```python
 %%qsharp
 
 open Microsoft.Quantum.Diagnostics;
@@ -184,7 +184,7 @@ Basis State
 import qsharp
 ```
 
-```qsharp
+```python
 %%qsharp
 
 use qubits = Qubit[2];
@@ -206,7 +206,7 @@ Basis State
 ```
 
 
-```qsharp
+```python
 %%qsharp
 R1Frac(1, 2, qubits[0]);
 R1Frac(1, 3, qubits[1]);


### PR DESCRIPTION
Bit of nitpick: The qsharp language header might be a bit confusing to someone new to the Q#. `%%qsharp` can only be used with jupyter notebook(python kernel with Q#) installed, so it might be helpful to say python, all along the way

Doc link: https://learn.microsoft.com/en-us/azure/quantum/user-guide/testing-debugging