### PR TITLE
Update references for Ankaa-9Q-3

### DIFF
--- a/articles/how-to-adapt-qiskit.md
+++ b/articles/how-to-adapt-qiskit.md
@@ -57,6 +57,7 @@ Most samples are configured to run by default against the `aer_simulator`, which
 
     # Create Rigetti simulator backend
     rigetti_simulator_backend = provider.get_backend("rigetti.sim.qvm")
+    rigetti_qpu_backend = provider.get_backend("rigetti.qpu.ankaa-9q-3")
 
     # Create Quantinuum simulator and QPU backends
     quantinuum_simulator_backend = provider.get_backend("quantinuum.sim.h1-1e")

--- a/articles/pricing.md
+++ b/articles/pricing.md
@@ -197,9 +197,39 @@ For more information about Azure infrastructure costs, see [Azure Blob Storage p
 ***
 ## Rigetti
 
-The [Quantum Virtual Machine (QVM)](https://pyquil-docs.rigetti.com/en/1.9/qvm.html) simulator is free for all users.
+[Rigetti](https://rigetti.com) charges for job execution time on their quantum processors. There is no added charge per job, per shot, or per gate. The [Quantum Virtual Machine (QVM)](https://github.com/quil-lang/qvm) simulator is free for all users.
+
 
 To learn more about Rigetti, visit the [Rigetti provider page](xref:microsoft.quantum.providers.rigetti).
+
+
+All new Azure Quantum customers benefit from USD500 free Azure Quantum credits to use specifically for Rigetti targets. To learn more about credits, see [Azure Quantum Credits](xref:microsoft.quantum.credits).
+
+In addition to the Azure Quantum Credits plan, Rigetti offers a pay-as-you-go plan for live quantum processors, so you pay only for what you use.
+
+### [Azure Quantum Credits](#tab/tabid-AQcreditsRigetti)
+
+Azure Quantum Credits consumption is based on a resource-usage model and cost of use is deducted from your credit balance. To learn more about credits, see [Azure Quantum Credits](xref:microsoft.quantum.credits).
+
+|Pricing | Includes access to  |
+|---|---|  
+|Use is deducted from the Azure Quantum Credits based on the job execution time only| Rigetti Ankaa-9Q-3|
+
+> [!NOTE]
+> Once you have consumed all the credits you need to switch to a different plan to continue using Rigetti. Azure Quantum won’t charge you when you reach your credit limit.
+
+> [!IMPORTANT]
+> There are no costs or charges for using your free credits. However, there may be some small storage costs, as the input and output of your credits jobs are stored in a storage account that you pay for. Job data is typically <1MB per job. 
+> For more details, see [Azure Blob Storage pricing](https://azure.microsoft.com/pricing/details/storage/blobs/).
+ 
+### [Pay As You Go](#tab/tabid-paygoRigetti)
+
+The Pay-as-you-go plan consists of *a la carte* access to Rigetti QPUs. The usage is charged based on the job execution time only.
+
+|Pricing | Includes access to   |
+|---|---|  
+|USD 0.013 per 10-millisecond increment of job execution time| Rigetti 9-qubit Ankaa-9Q-3 |
+
 
 ***
 

--- a/articles/provider-rigetti.md
+++ b/articles/provider-rigetti.md
@@ -16,7 +16,7 @@ uid: microsoft.quantum.providers.rigetti
 [!INCLUDE [Azure Quantum credits banner](includes/azure-quantum-credits.md)]
 
 > [!NOTE]
-> The Ankaa-2 QPU is deprecated from the Azure Quantum service as of October 4, 2024. 
+> The Ankaa-2 QPU is retired from the Azure Quantum service as of October 4, 2024. 
 
 [Rigetti quantum processors](https://qcs.rigetti.com/qpus) are universal, gate-model machines based on tunable superconducting qubits. System features and device characteristics include enhanced readout capabilities, a speedup in quantum processing times, fast gate times for multiple entangling gate families, rapid sampling via active register reset, and parametric control.
 
@@ -28,11 +28,25 @@ The Rigetti provider makes the following targets available:
 |Target name|Target ID|Number of qubits|Description|
 |---|---|---|---|
 |[Quantum Virtual Machine (QVM)](#simulators) |	rigetti.sim.qvm	|-| Open-source simulator for Quil, Q\#, and Qiskit programs. Free of cost.|
+|[Ankaa-9Q-3](#ankaa-9q-3) |rigetti.qpu.ankaa-9q-3 | 9 qubits|  |
 
 > [!NOTE]
 > Rigetti simulators and hardware targets do not support Cirq programs. 
 
-Rigetti's targets correspond to a **:::no-loc text="QIR Base":::** profile. For more information about this target profile and its limitations, see [Understanding target profile types in Azure Quantum](xref:microsoft.quantum.target-profiles#create-and-run-applications-for-base-qir-profile-targets). 
+Rigetti's targets correspond to a **:::no-loc text="QIR Base":::** profile. For more information about this target profile and its limitations, see [Understanding target profile types in Azure Quantum](xref:microsoft.quantum.target-profiles#create-and-run-applications-for-base-qir-profile-targets).
+
+## Quantum computers
+
+All of Rigetti's publicly available [QPUs](https://qcs.rigetti.com/qpus) are available through Azure Quantum. This list is subject to change without advance notice.
+
+### Ankaa-9Q-3
+
+A 9-qubit quantum processor.
+
+- Job Type: `Quantum Program`
+- Data Format: `rigetti.quil.v1`, `rigetti.qir.v1`
+- Target ID: `rigetti.qpu.ankaa-9q-3`
+- Target Execution Profile: [:::no-loc text="QIR Base":::](xref:microsoft.quantum.target-profiles#create-and-run-applications-for-base-qir-profile-targets)
 
 ## Simulators
 
@@ -129,7 +143,7 @@ workspace = Workspace(
 
 target = Rigetti(
     workspace=workspace,
-    name=RigettiTarget.ANKAA_2,  # Defaults to RigettiTarget.QVM for simulation
+    name=RigettiTarget.ANKAA_9Q_3,  # Defaults to RigettiTarget.QVM for simulation
 )
 
 # Any valid Quil program is accepted, but the readout must be named `ro`

--- a/articles/qc-target-list.md
+++ b/articles/qc-target-list.md
@@ -49,7 +49,9 @@ Microsoft's provider partners offer a wide-range of qubit availability for their
 |[Quantinuum H1-1](xref:microsoft.quantum.providers.quantinuum#system-model-h1)|20 qubits|
 |[Quantinuum H1-2](xref:microsoft.quantum.providers.quantinuum#system-model-h1)| 20 qubits|
 |[Quantinuum H2-1](xref:microsoft.quantum.providers.quantinuum#system-model-h2)| 32 qubits|
-|[Rigetti Quantum Virtual Machine (QVM)](xref:microsoft.quantum.providers.rigetti#simulators) |30 qubits|  
+|[Rigetti Quantum Virtual Machine (QVM)](xref:microsoft.quantum.providers.rigetti#simulators) |30 qubits|
+|[Rigetti Ankaa-9Q-3](xref:microsoft.quantum.providers.rigetti#ankaa-9q-3) |9 qubits|
+
 
 ## Coming soon to Azure Quantum
 

--- a/articles/quickstart-microsoft-provider-format.md
+++ b/articles/quickstart-microsoft-provider-format.md
@@ -517,11 +517,11 @@ You can also construct Quil programs manually and submit them using the `azure-q
     from pyquil_for_azure_quantum import get_qpu, get_qvm
     ```
 
-1. Use the `get_qvm` or `get_qpu` function to get a connection to the QVM.
+1. Use the `get_qvm` or `get_qpu` function to get a connection to the QVM or QPU.
 
     ```python
     qc = get_qvm()  # For simulation
-
+    # qc = get_qpu("Ankaa-9Q-3") for submitting to a QPU
     ```
 
 1. Create a Quil program. Any valid Quil program is accepted, but the readout **must** be named `ro`.


### PR DESCRIPTION
Now that Ankaa-9Q-3 is online, this updates the documentation to reflect it in all the places where Ankaa-2 once was. 

See [Ankaa-2 removal](https://github.com/MicrosoftDocs/quantum-docs/commit/5e5f416ba9acdaf7b94e83217adf3291df7fb68d) for comparison.

~~Note: this should not be merged until confirming that the SDK supports Ankaa-9Q-3 and that the example is valid~~ [Good to go](https://github.com/microsoft/azure-quantum-python/blob/b031de3f8850c7926d42e48462fcf352f7f50d3a/azure-quantum/azure/quantum/target/rigetti/target.py#L32)