### PR TITLE
[PASQAL] Add missing python imports for Pulser sequence documentation

### DIFF
--- a/articles/quickstart-microsoft-provider-format.md
+++ b/articles/quickstart-microsoft-provider-format.md
@@ -274,7 +274,7 @@ To submit the pulse sequences, first install the Pulser SDK packages:
 try:
     import pulser
 except ImportError:
-    !pip -q install pulser
+    !pip -q install pulser pulser-pasqal
 ```
 
 #### Create a quantum register
@@ -325,6 +325,7 @@ For any given arbitrary register, a neutral-atom QPU will place traps according 
     This option allows for the automatic generation of a layout based on a specified register. However, for large registers, this process may yield sub-optimal solutions due to limitations in the algorithm used to create the layout.
     
     ```python
+    from pulser import Register
     qubits = {
         "q0": (0, 0),
         "q1": (0, 10),
@@ -343,6 +344,7 @@ For any given arbitrary register, a neutral-atom QPU will place traps according 
 
     ```python
     import numpy as np
+    from pulser.register.register_layout import RegisterLayout
 
     # Generating random coordinates
     np.random.seed(301122)  # Keeps results consistent between runs


### PR DESCRIPTION
A few imports were missing in the documentation, this MR should fix it.