### PR TITLE
[FIX] Target pypi index explicitly

### DIFF
--- a/articles/quickstart-microsoft-provider-format.md
+++ b/articles/quickstart-microsoft-provider-format.md
@@ -273,8 +273,9 @@ To submit the pulse sequences, first install the Pulser SDK packages:
 ```python
 try:
     import pulser
+    import pulser_pasqal
 except ImportError:
-    !pip -q install pulser pulser-pasqal
+    !pip -q install pulser pulser-pasqal --index-url https://pypi.org/simple
 ```
 
 #### Create a quantum register


### PR DESCRIPTION
Installing dependencies with pip without targeting explicitly the pypi index in an Azure workspace is now failing. Update the documentation to make sure users can install Pasqal dependencies properly.