### PR TITLE
Fix the code

### DIFF
--- a/articles/includes/quickstart-cirq-include-portal.md
+++ b/articles/includes/quickstart-cirq-include-portal.md
@@ -50,7 +50,7 @@ from azure.quantum.cirq import AzureQuantumService
 Next, create an `AzureQuantumService` object using the `workspace` object from the previous cell to connect to your Azure Quantum workspace.  Add a new cell with the following code:
 
 ```python
-provider = AzureQuantumService(workspace)
+service = AzureQuantumService(workspace)
 ```
 
 ## Define a simple circuit


### PR DESCRIPTION
This pull request makes a small update to the example code in the documentation to improve clarity and consistency. The variable name used when creating the `AzureQuantumService` object is changed from `provider` to `service`.